### PR TITLE
Add security headers and API rate limiting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ webpack.config.ts
 .eslintrc.js
 jest.config.js
 coverage/
+next.config.js

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Automatic portfolio creation based on Github profile.
 - Rename the forked repository to **\<username>.github.io** | *[Settings -> Repository name]*
 - Enable Github Actions and `profile.yml` for autodeploy | *[Actions tab -> profile.yml]*
 - [Generate new access token](https://github.com/settings/tokens/new) and add this value to the repository settings as `ACCESS_TOKEN` | *[Settings -> Secret]*
+- Use Vercel Environment Variables to store tokens and other secrets. Never expose these values in client components.
 - Fill the [`config.ts`](#config) file in root directory with your data and push changes
 - Change Github page to `gh-pages` branch | *[Settings -> Pages -> Source]*
 - Open the site (**\<username>.github.io**)

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,32 @@
+const ContentSecurityPolicy = "script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com";
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy,
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+];
+
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface Bucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const CAPACITY = 60;
+const REFILL_INTERVAL_MS = 60_000;
+const RATE = CAPACITY / REFILL_INTERVAL_MS;
+
+const buckets = new Map<string, Bucket>();
+
+export default function rateLimiter(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const ip = (req.headers['x-real-ip'] as string) || req.ip;
+  const now = Date.now();
+
+  let bucket = buckets.get(ip);
+  if (!bucket) {
+    bucket = { tokens: CAPACITY, lastRefill: now };
+    buckets.set(ip, bucket);
+  }
+
+  const elapsed = now - bucket.lastRefill;
+  bucket.tokens = Math.min(CAPACITY, bucket.tokens + elapsed * RATE);
+  bucket.lastRefill = now;
+
+  if (bucket.tokens < 1) {
+    res.status(429).send('Too Many Requests');
+    return;
+  }
+
+  bucket.tokens -= 1;
+  next();
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,12 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import rateLimiter from '../../middleware/rateLimiter';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    app.use('/api', rateLimiter);
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);


### PR DESCRIPTION
## Summary
- add security headers (CSP, frame options, HSTS, referrer policy)
- document secret handling with Vercel env vars
- implement token-bucket rate limiter for API routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d28b8b488328b3c163692d7f5c12