### PR TITLE
feat: add basic i18n and locale utilities

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -44,7 +44,7 @@ export default class Application implements IApplication {
 
     this.services.forEach((service) => service.applyConfigurations(this));
 
-    this.siteUrl = new SiteUrlResolver(this.config.global.www).resolve();
+    this.siteUrl = new SiteUrlResolver(this.config.global.www, this.config.global.locale).resolve();
   }
 
   get config(): IConfig {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "repositories": "Repositories",
+  "showMore": "Show more"
+}

--- a/src/modules/core/SiteUrlResolver.ts
+++ b/src/modules/core/SiteUrlResolver.ts
@@ -4,8 +4,11 @@ import { IConfigGlobalWww } from '../../interfaces/IConfig';
 export default class SiteUrlResolver {
   private www: IConfigGlobalWww;
 
-  constructor(www: IConfigGlobalWww) {
+  private locale: string;
+
+  constructor(www: IConfigGlobalWww, locale: string) {
     this.www = www;
+    this.locale = locale;
   }
 
   public resolve() {
@@ -17,10 +20,8 @@ export default class SiteUrlResolver {
   }
 
   protected get path() {
-    if (!this.www.path) {
-      return '';
-    }
-
-    return StringUtils.ltrim(`/${this.www.path}`, '/');
+    const lang = this.locale.split('_')[0];
+    const basePath = this.www.path ? `/${StringUtils.ltrim(this.www.path, '/')}` : '';
+    return `/${lang}${basePath}`;
   }
 }

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,4 +1,13 @@
 (() => {
+  const defaultLocale = document.documentElement.lang || 'en';
+  const supportedLocales = [defaultLocale];
+  const pathLocale = window.location.pathname.split('/')[1];
+  if (!supportedLocales.includes(pathLocale)) {
+    const newUrl = `/${defaultLocale}${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.replace(newUrl);
+    return;
+  }
+
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');

--- a/src/templates/_common/templates/header/basic.ejs
+++ b/src/templates/_common/templates/header/basic.ejs
@@ -6,9 +6,12 @@ const { TYPES } = require('../../../../types');
 const app = di.get(TYPES.Application)
 
 const { config, template } = app;
+const lang = config.global.locale.split('_')[0];
 %>
 
 <meta charset="utf-8">
 <meta name="generator" content="GPortfolio">
 <meta name="author" content="<%= template.info.author %>">
 <title><%= `${config.data.first_name} ${config.data.last_name}` %></title>
+<link rel="canonical" href="<%= app.url %>">
+<link rel="alternate" hrefLang="<%= lang %>" href="<%= app.url %>">

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -4,11 +4,14 @@
 const { di } = require('../../di');
 const { TYPES } = require('../../types');
 const { safeQuotes, resolveFile } = require('../_common/scripts/template');
+const useI18n = require('../../utils/i18n').default;
+const { formatDate } = require('../../utils/format');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
 
 const { config } = app;
+const { t } = useI18n(config.global.locale);
 
 const repositories = config.services.github.data.repositories;
 const repositoriesMore = config.templates.default.configuration.githubRepositoriesMore;
@@ -86,7 +89,7 @@ function generateRepositoriesHtml(repositories) {
             <span class="icon">
               <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="grid"><rect x="2" y="2" width="3" height="3"></rect><rect x="8" y="2" width="3" height="3"></rect><rect x="14" y="2" width="3" height="3"></rect><rect x="2" y="8" width="3" height="3"></rect><rect x="8" y="8" width="3" height="3"></rect><rect x="14" y="8" width="3" height="3"></rect><rect x="2" y="14" width="3" height="3"></rect><rect x="8" y="14" width="3" height="3"></rect><rect x="14" y="14" width="3" height="3"></rect></svg>
             </span>
-            <span>Repositories</span>
+            <span><%= t('repositories') %></span>
           </span>
         </h2>
         <div class="repositories">
@@ -94,7 +97,7 @@ function generateRepositoriesHtml(repositories) {
         </div>
         <% if (canShowMoreRepositories) { %>
           <div class="text--center mt-50">
-            <div id="github-more" class="btn-more">Show more</div>
+            <div id="github-more" class="btn-more"><%= t('showMore') %></div>
           </div>
         <% } %>
       </div>
@@ -103,7 +106,7 @@ function generateRepositoriesHtml(repositories) {
 </main>
 <footer>
   <hr class="divider-icon">
-  <span><%= new Date().toLocaleDateString(undefined, {
+  <span><%= formatDate(new Date(), config.global.locale, {
     year: 'numeric',
     day: '2-digit',
     month: '2-digit'

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,15 @@
+export function formatDate(
+  date: Date,
+  locale: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}
+
+export function formatNumber(
+  num: number,
+  locale: string,
+  options?: Intl.NumberFormatOptions,
+): string {
+  return new Intl.NumberFormat(locale, options).format(num);
+}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,12 @@
+const en = require('../locales/en.json') as Record<string, string>;
+
+const messages: Record<string, Record<string, string>> = { en };
+
+export default function useI18n(locale: string) {
+  const lang = locale.split('_')[0];
+  const dict = messages[lang] || messages.en;
+  return {
+    t: (key: string): string => dict[key] || key,
+    locale: lang,
+  };
+}

--- a/tests/modules/SiteUrlResolver.test.ts
+++ b/tests/modules/SiteUrlResolver.test.ts
@@ -6,9 +6,9 @@ describe('SiteUrlResolver', () => {
       domain: 'example.com',
       path: '/',
       protocol: 'https',
-    });
+    }, 'en_US');
 
-    expect(siteUrlResolver.resolve()).toBe('https://example.com');
+    expect(siteUrlResolver.resolve()).toBe('https://example.com/en');
   });
 
   it('Without last slash', () => {
@@ -16,8 +16,8 @@ describe('SiteUrlResolver', () => {
       domain: 'example.com',
       path: '/path',
       protocol: 'https',
-    });
+    }, 'en_US');
 
-    expect(siteUrlResolver.resolve()).toBe('https://example.com/path');
+    expect(siteUrlResolver.resolve()).toBe('https://example.com/en/path');
   });
 });

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,0 +1,19 @@
+import { formatDate, formatNumber } from '../../src/utils/format';
+
+describe('format utilities', () => {
+  it('formats dates using Intl', () => {
+    const date = new Date('2020-01-02T00:00:00Z');
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      day: '2-digit',
+      month: '2-digit',
+      timeZone: 'UTC',
+    };
+    expect(formatDate(date, 'en', options)).toBe(new Intl.DateTimeFormat('en', options).format(date));
+  });
+
+  it('formats numbers for RTL locales', () => {
+    const number = 1234.56;
+    expect(formatNumber(number, 'ar')).toBe(new Intl.NumberFormat('ar').format(number));
+  });
+});


### PR DESCRIPTION
## Summary
- centralize UI strings and expose `useI18n` hook
- prefix site URLs with locale and add client redirect
- add Intl-based date/number formatters with tests

## Testing
- `yarn lint && echo LINT_OK`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d28ddb7c8328b34cefccdf89a9c2