### PR TITLE
feat: add onboarding tour and dashboard empty components

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -103,6 +103,10 @@ export default class Application implements IApplication {
   get defaultGlobalData(): IConfigGlobal {
     return {
       locale: 'en_US',
+      language: 'en',
+      theme: 'light',
+      density: 'comfortable',
+      motion: 'default',
       opg: {},
       pwa: null,
       meta: {},

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -19,6 +19,10 @@ export default interface IConfig {
 
 export interface IConfigGlobal {
   locale: string
+  language: string
+  theme: 'light' | 'dark'
+  density: 'comfortable' | 'compact'
+  motion: 'default' | 'reduce'
   opg: object
   pwa: ManifestOptions | null
   meta: object

--- a/src/modules/dashboard/EmptyNotifications.tsx
+++ b/src/modules/dashboard/EmptyNotifications.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const containerStyle: React.CSSProperties = {
+  textAlign: 'center',
+  padding: '2rem',
+};
+
+const EmptyNotifications: React.FC = () => (
+  <div style={containerStyle}>
+    <p>No notifications yet.</p>
+    <button type="button" onClick={() => { /* placeholder */ }}>
+      Refresh
+    </button>
+  </div>
+);
+
+export default EmptyNotifications;
+

--- a/src/modules/dashboard/EmptyProjects.tsx
+++ b/src/modules/dashboard/EmptyProjects.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const containerStyle: React.CSSProperties = {
+  textAlign: 'center',
+  padding: '2rem',
+};
+
+const EmptyProjects: React.FC = () => (
+  <div style={containerStyle}>
+    <p>No projects have been created yet.</p>
+    <button type="button" onClick={() => { /* placeholder */ }}>
+      Create your first project
+    </button>
+  </div>
+);
+
+export default EmptyProjects;
+

--- a/src/modules/dashboard/EmptyTasks.tsx
+++ b/src/modules/dashboard/EmptyTasks.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const containerStyle: React.CSSProperties = {
+  textAlign: 'center',
+  padding: '2rem',
+};
+
+const EmptyTasks: React.FC = () => (
+  <div style={containerStyle}>
+    <p>You're all caught up. No tasks found.</p>
+    <button type="button" onClick={() => { /* placeholder */ }}>
+      Add a new task
+    </button>
+  </div>
+);
+
+export default EmptyTasks;
+

--- a/src/modules/dashboard/index.ts
+++ b/src/modules/dashboard/index.ts
@@ -1,0 +1,3 @@
+export { default as EmptyProjects } from './EmptyProjects.tsx';
+export { default as EmptyTasks } from './EmptyTasks.tsx';
+export { default as EmptyNotifications } from './EmptyNotifications.tsx';

--- a/src/modules/onboarding/Tour.tsx
+++ b/src/modules/onboarding/Tour.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+
+const TOUR_STORAGE_KEY = 'welcomeTourDismissed';
+
+interface Step {
+  title: string;
+  content: string;
+}
+
+const steps: Step[] = [
+  { title: 'Welcome', content: 'Welcome to the dashboard!' },
+  { title: 'Projects', content: 'Track your projects here.' },
+  { title: 'Settings', content: 'Adjust your preferences any time.' },
+];
+
+const Tour: React.FC = () => {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(TOUR_STORAGE_KEY);
+    if (!dismissed) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleNext = () => {
+    if (stepIndex + 1 < steps.length) {
+      setStepIndex(stepIndex + 1);
+    } else {
+      setVisible(false);
+    }
+  };
+
+  const handleSkip = () => {
+    setVisible(false);
+  };
+
+  const handleNeverShow = () => {
+    localStorage.setItem(TOUR_STORAGE_KEY, 'true');
+    setVisible(false);
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  const step = steps[stepIndex];
+
+  return (
+    <div className="tour-overlay" style={overlayStyle}>
+      <div className="tour-step" style={stepStyle}>
+        <h2>{step.title}</h2>
+        <p>{step.content}</p>
+        <div className="tour-actions" style={actionsStyle}>
+          <button type="button" onClick={handleSkip}>Skip</button>
+          <button type="button" onClick={handleNeverShow}>Never show again</button>
+          <button type="button" onClick={handleNext}>{stepIndex + 1 === steps.length ? 'Finish' : 'Next'}</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+const stepStyle: React.CSSProperties = {
+  background: '#fff',
+  padding: '2rem',
+  borderRadius: '4px',
+  textAlign: 'center',
+  maxWidth: '400px',
+};
+
+const actionsStyle: React.CSSProperties = {
+  marginTop: '1rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+};
+
+export default Tour;
+


### PR DESCRIPTION
## Summary
- add default UI settings for theme, density, motion and language
- introduce onboarding tour overlay with skip and never show again
- provide empty dashboard components with calls to action

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3d29a3b808328ac69672719c9c64a