### PR TITLE
feat: drag-and-drop uploads with previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.5"
+  },
+  "dependencies": {
+    "@vercel/blob": "^1.1.1"
   }
 }

--- a/src/modules/uploads/DropZone.tsx
+++ b/src/modules/uploads/DropZone.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react';
+
+export interface DropZoneProps {
+  onFiles: (files: File[]) => void;
+  accept?: string[];
+}
+
+/**
+ * Drag and drop area that validates file types and exposes hover state.
+ */
+const DropZone: React.FC<DropZoneProps> = ({ onFiles, accept = [] }) => {
+  const [hover, setHover] = useState(false);
+
+  const validate = useCallback(
+    (files: FileList): File[] => {
+      const arr = Array.from(files);
+      if (!accept.length) return arr;
+      return arr.filter((file) => accept.includes(file.type));
+    },
+    [accept],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setHover(false);
+      const files = validate(e.dataTransfer.files);
+      if (files.length) onFiles(files);
+    },
+    [onFiles, validate],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const list = e.target.files;
+      if (!list) return;
+      const files = validate(list);
+      if (files.length) onFiles(files);
+    },
+    [onFiles, validate],
+  );
+
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        setHover(true);
+      }}
+      onDragLeave={() => setHover(false)}
+      onDrop={handleDrop}
+      className={`dropzone${hover ? ' dropzone--hover' : ''}`}
+    >
+      <input
+        className="dropzone__input"
+        type="file"
+        multiple
+        accept={accept.join(',')}
+        onChange={handleChange}
+      />
+      <p>{hover ? 'Release to upload files' : 'Drag files here or click to browse'}</p>
+    </div>
+  );
+};
+
+export default DropZone;

--- a/src/modules/uploads/preview.ts
+++ b/src/modules/uploads/preview.ts
@@ -1,0 +1,122 @@
+export interface PreviewOptions {
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+async function readOrientation(file: File): Promise<number> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const view = new DataView(reader.result as ArrayBuffer);
+      if (view.getUint16(0, false) !== 0xFFD8) {
+        resolve(-2); // not jpeg
+        return;
+      }
+      let offset = 2;
+      while (offset < view.byteLength) {
+        const marker = view.getUint16(offset, false);
+        offset += 2;
+        if (marker === 0xFFE1) {
+          offset += 2; // skip length
+          if (view.getUint32(offset, false) !== 0x45786966) {
+            break;
+          }
+          offset += 6; // skip Exif\0\0
+          const little = view.getUint16(offset, false) === 0x4949;
+          offset += view.getUint32(offset + 4, little);
+          const tags = view.getUint16(offset, little);
+          offset += 2;
+          for (let i = 0; i < tags; i++) {
+            if (view.getUint16(offset + i * 12, little) === 0x0112) {
+              resolve(view.getUint16(offset + i * 12 + 8, little));
+              return;
+            }
+          }
+        } else if ((marker & 0xFF00) !== 0xFF00) {
+          break;
+        } else {
+          offset += view.getUint16(offset, false);
+        }
+      }
+      resolve(-1);
+    };
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function transform(ctx: CanvasRenderingContext2D, orientation: number, width: number, height: number) {
+  switch (orientation) {
+    case 2:
+      ctx.translate(width, 0);
+      ctx.scale(-1, 1);
+      break;
+    case 3:
+      ctx.translate(width, height);
+      ctx.rotate(Math.PI);
+      break;
+    case 4:
+      ctx.translate(0, height);
+      ctx.scale(1, -1);
+      break;
+    case 5:
+      ctx.rotate(0.5 * Math.PI);
+      ctx.scale(1, -1);
+      break;
+    case 6:
+      ctx.rotate(0.5 * Math.PI);
+      ctx.translate(0, -height);
+      break;
+    case 7:
+      ctx.rotate(0.5 * Math.PI);
+      ctx.translate(width, -height);
+      ctx.scale(-1, 1);
+      break;
+    case 8:
+      ctx.rotate(-0.5 * Math.PI);
+      ctx.translate(-width, 0);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Create an oriented, resized preview data URL for an image file.
+ */
+export async function createImagePreview(file: File, options: PreviewOptions = {}): Promise<string> {
+  const orientation = await readOrientation(file);
+  const url = URL.createObjectURL(file);
+  const img = await loadImage(url);
+  URL.revokeObjectURL(url);
+
+  const { maxWidth = 1024, maxHeight = 1024 } = options;
+  let { width, height } = img;
+  const scale = Math.min(1, maxWidth / width, maxHeight / height);
+  width *= scale;
+  height *= scale;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  if ([5, 6, 7, 8].includes(orientation)) {
+    canvas.width = height;
+    canvas.height = width;
+  } else {
+    canvas.width = width;
+    canvas.height = height;
+  }
+
+  transform(ctx, orientation, width, height);
+  ctx.drawImage(img, 0, 0, width, height);
+
+  return canvas.toDataURL('image/png');
+}

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+/**
+ * Generates signed upload URLs for Vercel Blob storage.
+ */
+export default async function upload(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const body = (req.body ?? {}) as HandleUploadBody;
+  const json = await handleUpload({
+    request: req,
+    body,
+    onBeforeGenerateToken: async () => ({
+      allowedContentTypes: ['image/*'],
+    }),
+  });
+
+  res.status(200).json(json);
+}


### PR DESCRIPTION
## Summary
- add DropZone component with file type validation and hover states
- introduce image preview pipeline fixing orientation and resizing
- add Vercel Blob upload API route and dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d29dda2083289087f86eb6a831f9