### PR TITLE
Add error pages, module boundaries, and network retry utility

### DIFF
--- a/src/modules/core/ErrorBoundary.tsx
+++ b/src/modules/core/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>Something went wrong.</p>
+          <button type="button" onClick={this.reset}>Try again</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/modules/filter/ErrorBoundary.tsx
+++ b/src/modules/filter/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>Something went wrong.</p>
+          <button type="button" onClick={this.reset}>Try again</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/modules/logger/ErrorBoundary.tsx
+++ b/src/modules/logger/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>Something went wrong.</p>
+          <button type="button" onClick={this.reset}>Try again</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/modules/server/ErrorBoundary.tsx
+++ b/src/modules/server/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>Something went wrong.</p>
+          <button type="button" onClick={this.reset}>Try again</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/modules/sorter/ErrorBoundary.tsx
+++ b/src/modules/sorter/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(error, info);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>Something went wrong.</p>
+          <button type="button" onClick={this.reset}>Try again</button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const NotFoundPage: React.FC = () => (
+  <main className="error-page">
+    <h1>404 - Page Not Found</h1>
+    <p>The page you are looking for doesn’t exist.</p>
+    <a href="/">Go back home</a>
+    <button
+      type="button"
+      onClick={() => {
+        window.location.href = 'mailto:support@example.com?subject=404%20Error';
+      }}
+    >
+      Report issue
+    </button>
+  </main>
+);
+
+export default NotFoundPage;

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const ServerErrorPage: React.FC = () => (
+  <main className="error-page">
+    <h1>500 - Server Error</h1>
+    <p>Something went wrong on our side.</p>
+    <a href="/">Go back home</a>
+    <button
+      type="button"
+      onClick={() => {
+        window.location.href = 'mailto:support@example.com?subject=500%20Error';
+      }}
+    >
+      Report issue
+    </button>
+  </main>
+);
+
+export default ServerErrorPage;

--- a/src/services/github/fetcher/GithubPrivateFetcher.ts
+++ b/src/services/github/fetcher/GithubPrivateFetcher.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import GithubRequest from '../GithubRequest';
 import IGithubFetcher from '../interfaces/IGithubFetcher';
 import IGithubConfigRepository from '../interfaces/IGithubConfigRepository';
+import retry from '../../../utils/network/retry';
 
 export default class GithubPrivateFetcher implements IGithubFetcher {
   protected token: string;
@@ -18,7 +19,7 @@ export default class GithubPrivateFetcher implements IGithubFetcher {
   }
 
   public fetchProfile(): Promise<AxiosResponse> {
-    return this.axios.get(`${GithubRequest.API}/user`);
+    return retry(() => this.axios.get(`${GithubRequest.API}/user`));
   }
 
   public fetchRepositories(
@@ -26,7 +27,7 @@ export default class GithubPrivateFetcher implements IGithubFetcher {
     page = 1,
     perPage: number = GithubRequest.REPOS_MAX_COUNT,
   ): Promise<AxiosResponse> {
-    return this.axios.get(`${GithubRequest.API}/user/repos`, {
+    return retry(() => this.axios.get(`${GithubRequest.API}/user/repos`, {
       params: {
         affiliation: params.affiliation.length ? params.affiliation.join(',') : undefined,
         visibility: params.visibility,
@@ -36,6 +37,6 @@ export default class GithubPrivateFetcher implements IGithubFetcher {
         page,
         per_page: perPage,
       },
-    });
+    }));
   }
 }

--- a/src/services/github/fetcher/GithubPublicFetcher.ts
+++ b/src/services/github/fetcher/GithubPublicFetcher.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import GithubRequest from '../GithubRequest';
 import IGithubFetcher from '../interfaces/IGithubFetcher';
 import IGithubConfigRepository from '../interfaces/IGithubConfigRepository';
+import retry from '../../../utils/network/retry';
 
 export default class GithubPublicFetcher implements IGithubFetcher {
   protected username: string;
@@ -14,7 +15,7 @@ export default class GithubPublicFetcher implements IGithubFetcher {
   }
 
   public fetchProfile(): Promise<AxiosResponse> {
-    return this.axios.get(`${GithubRequest.API}/users/${this.username}`);
+    return retry(() => this.axios.get(`${GithubRequest.API}/users/${this.username}`));
   }
 
   public fetchRepositories(
@@ -22,7 +23,7 @@ export default class GithubPublicFetcher implements IGithubFetcher {
     page = 1,
     perPage: number = GithubRequest.REPOS_MAX_COUNT,
   ): Promise<AxiosResponse> {
-    return this.axios.get(`${GithubRequest.API}/users/${this.username}/repos`, {
+    return retry(() => this.axios.get(`${GithubRequest.API}/users/${this.username}/repos`, {
       params: {
         type: params.type,
         sort: params.sort,
@@ -30,6 +31,6 @@ export default class GithubPublicFetcher implements IGithubFetcher {
         page,
         per_page: perPage,
       },
-    });
+    }));
   }
 }

--- a/src/utils/network/retry.ts
+++ b/src/utils/network/retry.ts
@@ -1,0 +1,45 @@
+export interface RetryOptions {
+  retries?: number;
+  factor?: number;
+  minTimeout?: number;
+  maxTimeout?: number;
+  jitter?: boolean;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export default async function retry<T>(
+  fn: () => Promise<T>,
+  {
+    retries = 3,
+    factor = 2,
+    minTimeout = 100,
+    maxTimeout = 1000,
+    jitter = true,
+  }: RetryOptions = {},
+): Promise<T> {
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt += 1;
+      if (attempt > retries) {
+        throw err;
+      }
+
+      let timeout = Math.min(maxTimeout, minTimeout * factor ** (attempt - 1));
+      if (jitter) {
+        timeout = Math.random() * timeout;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await wait(timeout);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add branded 404 and 500 React pages with navigation link and report button
- Introduce ErrorBoundary components for each app module to capture and reset state
- Provide client retry utility with exponential backoff and jitter and apply to GitHub fetchers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d29f2d888328a2252deb9e341778