### PR TITLE
Add personalized client fetch with skeleton and caching

### DIFF
--- a/src/modules/fetch/clientPersonalized.ts
+++ b/src/modules/fetch/clientPersonalized.ts
@@ -1,0 +1,4 @@
+export default async function fetchPersonalized(): Promise<any> {
+  const resp = await fetch('/api/personalized');
+  return resp.json();
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,11 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import personalizedHandler from '../../pages/api/personalized';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.get('/api/personalized', personalizedHandler);
   }
 }

--- a/src/modules/skeletons/PersonalizedSkeleton.ts
+++ b/src/modules/skeletons/PersonalizedSkeleton.ts
@@ -1,0 +1,5 @@
+export default function createPersonalizedSkeleton(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'skeleton personalized-skeleton';
+  return el;
+}

--- a/src/modules/skeletons/skeleton.scss
+++ b/src/modules/skeletons/skeleton.scss
@@ -1,0 +1,12 @@
+.skeleton {
+  background-color: #eee;
+  border-radius: 4px;
+  min-height: 1em;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}

--- a/src/pages/api/personalized.ts
+++ b/src/pages/api/personalized.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+
+export const revalidate = 60;
+
+export default function handler(req: Request, res: Response): void {
+  res.setHeader(
+    'Cache-Control',
+    `public, max-age=0, s-maxage=${revalidate}, stale-while-revalidate=${revalidate * 5}`,
+  );
+  res.json({ message: 'Hello from personalized endpoint' });
+}

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -78,6 +78,11 @@ function generateRepositoriesHtml(repositories) {
   </div>
 </header>
 <main>
+  <section id="personalized-section" class="section">
+    <div class="container">
+      <div id="personalized"></div>
+    </div>
+  </section>
   <% if (repositories.length > 0) { %>
     <section class="repositories-section section">
       <div class="container">

--- a/src/templates/default/index.ts
+++ b/src/templates/default/index.ts
@@ -1,1 +1,19 @@
 import '../_common/scripts';
+import createPersonalizedSkeleton from '../../modules/skeletons/PersonalizedSkeleton';
+import fetchPersonalized from '../../modules/fetch/clientPersonalized';
+import '../../modules/skeletons/skeleton.scss';
+
+window.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('personalized');
+  if (!container) {
+    return;
+  }
+
+  const skeleton = createPersonalizedSkeleton();
+  container.appendChild(skeleton);
+
+  fetchPersonalized().then((data) => {
+    container.removeChild(skeleton);
+    container.textContent = data.message;
+  });
+});


### PR DESCRIPTION
## Summary
- add personalized API with stale-while-revalidate cache headers
- show personalized section with skeleton and client fetch
- register API route on server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2a096a483288766ecd852973a76