### PR TITLE
feat: add i18n messages and RTL-aware helpers

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!i18n/
+!i18n/messages.json

--- a/data/i18n/messages.json
+++ b/data/i18n/messages.json
@@ -1,0 +1,12 @@
+{
+  "settings.title": "GPortfolio - Settings",
+  "settings.section.global": "Global",
+  "settings.label.template": "Template",
+  "settings.description.selectTemplate": "Select an existing template",
+  "settings.label.base": "Base",
+  "settings.description.base": "If the repository is called: \u003cusername\u003e.github.io. Then the value is empty If the repository is called: portfolio, or any other name. Then the value of \u003cname of repository\u003e",
+  "repositories.title": "Repositories",
+  "repositories.showMore": "Show more",
+  "meta.generator": "GPortfolio",
+  "meta.portfolioBy": "Portfolio by"
+}

--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -1,8 +1,11 @@
-<% require('reflect-metadata'); %>
+<%
+require('reflect-metadata');
+const messages = require('../../../data/i18n/messages.json');
+%>
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>GPortfolio - Settings</title>
+    <title><%= messages['settings.title'] %></title>
     <style>
     @font-face {
         font-family: 'JetBrainsMono';
@@ -57,30 +60,29 @@
 <!--</section>-->
 <section>
     <div class="section--name">
-        Global
+        <%= messages['settings.section.global'] %>
     </div>
     <div class="section--items">
         <div class="block">
             <div class="block--label">
-                Template
+                <%= messages['settings.label.template'] %>
             </div>
             <div class="block--input">
                 <input/>
             </div>
             <div class="block--description">
-                Select an existing template
+                <%= messages['settings.description.selectTemplate'] %>
             </div>
         </div>
         <div class="block">
             <div class="block--label">
-                Base
+                <%= messages['settings.label.base'] %>
             </div>
             <div class="block--input">
                 <input/>
             </div>
             <div class="block--description">
-                If the repository is called: &lt;username&gt;.github.io. Then the value is empty
-                If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;
+                <%= messages['settings.description.base'] %>
             </div>
         </div>
     </div>

--- a/src/templates/_common/templates/header/basic.ejs
+++ b/src/templates/_common/templates/header/basic.ejs
@@ -1,6 +1,7 @@
 <%
 const { di } = require('../../../../di');
 const { TYPES } = require('../../../../types');
+const messages = require('../../../../../data/i18n/messages.json');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application)
@@ -9,6 +10,6 @@ const { config, template } = app;
 %>
 
 <meta charset="utf-8">
-<meta name="generator" content="GPortfolio">
+<meta name="generator" content="<%= messages['meta.generator'] %>">
 <meta name="author" content="<%= template.info.author %>">
 <title><%= `${config.data.first_name} ${config.data.last_name}` %></title>

--- a/src/templates/_common/templates/header/opg.ejs
+++ b/src/templates/_common/templates/header/opg.ejs
@@ -2,6 +2,7 @@
 const { resolveFile } = require('../../scripts/template');
 const { di } = require('../../../../di');
 const { TYPES } = require('../../../../types');
+const messages = require('../../../../../data/i18n/messages.json');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
@@ -9,7 +10,7 @@ const app = di.get(TYPES.Application);
 const { config, url } = app;
 %>
 
-<meta property="og:title" content="Portfolio by <%= `${config.data.first_name} ${config.data.last_name}` %>" />
+<meta property="og:title" content="<%= messages['meta.portfolioBy'] %> <%= `${config.data.first_name} ${config.data.last_name}` %>" />
 <meta property="og:type" content="profile" />
 <meta property="og:image" content="<%= resolveFile(config.data.avatar) %>" />
 <meta property="og:url" content="<%= url %>" />

--- a/src/templates/_common/templates/html-attributes.ejs
+++ b/src/templates/_common/templates/html-attributes.ejs
@@ -44,6 +44,7 @@ const app = di.get(TYPES.Application);
 
 const { config } = app;
 const lang = config.global.locale.split('_')[0];
+const isRtl = config.templates[templateName]?.configuration?.rtl;
 %>
 
-lang="<%= lang %>" data-template="<%= templateName %>" time-compiled="<%= Date.now() %>"
+lang="<%= lang %>" dir="<%= isRtl ? 'rtl' : 'ltr' %>" data-template="<%= templateName %>" time-compiled="<%= Date.now() %>"

--- a/src/templates/default/config/di.ts
+++ b/src/templates/default/config/di.ts
@@ -16,6 +16,7 @@ export default (di: Container) => {
     configuration: {
       background: () => require('../assets/background.png'),
       githubRepositoriesMore: 24,
+      rtl: false,
     },
   }) as IDefaultTemplate);
 };

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -4,6 +4,8 @@
 const { di } = require('../../di');
 const { TYPES } = require('../../types');
 const { safeQuotes, resolveFile } = require('../_common/scripts/template');
+const messages = require('../../../data/i18n/messages.json');
+const { formatDate, formatNumber } = require('../../utils/intl');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
@@ -31,11 +33,11 @@ function generateRepositoriesHtml(repositories) {
           </div>
           <div class="repository__footer__star">
             <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="star"><polygon fill="none" stroke="#000" stroke-width="1.01" points="10 2 12.63 7.27 18.5 8.12 14.25 12.22 15.25 18 10 15.27 4.75 18 5.75 12.22 1.5 8.12 7.37 7.27"></polygon></svg>
-            <span>${repositories[i].stargazers_count}</span>
+            <span>${formatNumber(repositories[i].stargazers_count)}</span>
           </div>
           <div class="repository__footer__forks">
             <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="git-fork"><circle fill="none" stroke="#000" stroke-width="1.2" cx="5.79" cy="2.79" r="1.79"></circle><circle fill="none" stroke="#000" stroke-width="1.2" cx="14.19" cy="2.79" r="1.79"></circle><circle fill="none" stroke="#000" stroke-width="1.2" cx="10.03" cy="16.79" r="1.79"></circle><path fill="none" stroke="#000" stroke-width="2" d="M5.79,4.57 L5.79,6.56 C5.79,9.19 10.03,10.22 10.03,13.31 C10.03,14.86 10.04,14.55 10.04,14.55 C10.04,14.37 10.04,14.86 10.04,13.31 C10.04,10.22 14.2,9.19 14.2,6.56 L14.2,4.57"></path></svg>
-            <span>${repositories[i].forks_count}</span>
+            <span>${formatNumber(repositories[i].forks_count)}</span>
           </div>
         </div>
       </a>`;
@@ -86,7 +88,7 @@ function generateRepositoriesHtml(repositories) {
             <span class="icon">
               <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="grid"><rect x="2" y="2" width="3" height="3"></rect><rect x="8" y="2" width="3" height="3"></rect><rect x="14" y="2" width="3" height="3"></rect><rect x="2" y="8" width="3" height="3"></rect><rect x="8" y="8" width="3" height="3"></rect><rect x="14" y="8" width="3" height="3"></rect><rect x="2" y="14" width="3" height="3"></rect><rect x="8" y="14" width="3" height="3"></rect><rect x="14" y="14" width="3" height="3"></rect></svg>
             </span>
-            <span>Repositories</span>
+            <span><%= messages['repositories.title'] %></span>
           </span>
         </h2>
         <div class="repositories">
@@ -94,7 +96,7 @@ function generateRepositoriesHtml(repositories) {
         </div>
         <% if (canShowMoreRepositories) { %>
           <div class="text--center mt-50">
-            <div id="github-more" class="btn-more">Show more</div>
+            <div id="github-more" class="btn-more"><%= messages['repositories.showMore'] %></div>
           </div>
         <% } %>
       </div>
@@ -103,7 +105,7 @@ function generateRepositoriesHtml(repositories) {
 </main>
 <footer>
   <hr class="divider-icon">
-  <span><%= new Date().toLocaleDateString(undefined, {
+  <span><%= formatDate(new Date(), {
     year: 'numeric',
     day: '2-digit',
     month: '2-digit'

--- a/src/templates/default/interfaces/IDefaultTemplate.ts
+++ b/src/templates/default/interfaces/IDefaultTemplate.ts
@@ -10,5 +10,6 @@ export default interface IDefaultTemplate extends ITemplate {
      * 0 - display all
      */
     githubRepositoriesMore: number
+    rtl: boolean
   }
 }

--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -5,7 +5,7 @@
   &__background {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     z-index: -1;
@@ -17,7 +17,7 @@
       content: "";
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       width: 100%;
       height: 100%;
       background: rgba(0, 0, 0, .3)

--- a/src/templates/default/styles/helper.scss
+++ b/src/templates/default/styles/helper.scss
@@ -1,6 +1,5 @@
 .mx--auto {
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
 }
 
 .text--center {
@@ -42,11 +41,11 @@
     border-bottom: 1px solid #e5e5e5;
   }
   &::before {
-    right: calc(50% + (50px / 2));
+    inset-inline-end: calc(50% + (50px / 2));
     width: 100%;
   }
   &::after {
-    left: calc(50% + (50px / 2));
+    inset-inline-start: calc(50% + (50px / 2));
     width: 100%;
   }
 }

--- a/src/templates/default/styles/repositories.scss
+++ b/src/templates/default/styles/repositories.scss
@@ -49,11 +49,11 @@
       display: flex;
       align-items: center;
       &:not(:last-child) {
-        margin-right: 15px;
+        margin-inline-end: 15px;
       }
       svg {
         width: 15px;
-        margin-right: 5px;
+        margin-inline-end: 5px;
       }
     }
   }

--- a/src/templates/default/styles/sections.scss
+++ b/src/templates/default/styles/sections.scss
@@ -1,10 +1,8 @@
 .container {
   box-sizing: content-box;
   max-width: 1600px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 15px;
-  padding-right: 15px;
+  margin-inline: auto;
+  padding-inline: 15px;
 }
 
 .section {
@@ -22,16 +20,16 @@
       display: flex;
       align-items: center;
       > .icon {
-        margin-right: 10px;
+        margin-inline-end: 10px;
       }
       &::after {
         content: "";
         position: absolute;
         top: calc(50% - ((.2px + .05em)/ 2));
-        left: 100%;
+        inset-inline-start: 100%;
         width: 2000px;
         border-bottom: calc(.2px + .05em) solid #e5e5e5;
-        margin-left: calc(5px + .3em);
+        margin-inline-start: calc(5px + .3em);
       }
     }
   }

--- a/src/utils/intl.ts
+++ b/src/utils/intl.ts
@@ -1,0 +1,14 @@
+import { di } from '../di';
+import { TYPES } from '../types';
+
+export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions, locale?: string): string {
+  const { config } = di.get(TYPES.Application);
+  const lang = locale || config.global.locale;
+  return new Intl.DateTimeFormat(lang, options).format(date);
+}
+
+export function formatNumber(value: number, options?: Intl.NumberFormatOptions, locale?: string): string {
+  const { config } = di.get(TYPES.Application);
+  const lang = locale || config.global.locale;
+  return new Intl.NumberFormat(lang, options).format(value);
+}


### PR DESCRIPTION
## Summary
- centralize user-facing text in `data/i18n/messages.json` and reference via keys
- add locale-aware `formatDate` and `formatNumber` helpers
- enable RTL layouts with logical CSS properties and a template `rtl` flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d2a27ab08328b51e4e086bdb768e