### PR TITLE
Add CSP, privacy consent, and rate limiting features

### DIFF
--- a/src/modules/privacy/consent.ts
+++ b/src/modules/privacy/consent.ts
@@ -1,0 +1,22 @@
+export default class Consent {
+  static hasConsent(cookieName = 'cookie_consent'): boolean {
+    if (typeof document === 'undefined') {
+      return false;
+    }
+    return document.cookie.split(';').map((c) => c.trim()).some((c) => c === `${cookieName}=1`);
+  }
+
+  static isDoNotTrack(): boolean {
+    if (typeof navigator === 'undefined') {
+      return false;
+    }
+    const dnt = (navigator as any).doNotTrack
+      || (navigator as any).msDoNotTrack
+      || (typeof window !== 'undefined' && (window as any).doNotTrack);
+    return dnt === '1' || dnt === 'yes';
+  }
+
+  static canUseCookies(): boolean {
+    return this.hasConsent() && !this.isDoNotTrack();
+  }
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,26 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import {
+  Application,
+  Request,
+  Response,
+  NextFunction,
+} from 'express';
+import crypto from 'crypto';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      const nonce = crypto.randomBytes(16).toString('base64');
+      res.locals.nonce = nonce;
+      res.setHeader(
+        'Content-Security-Policy',
+        `default-src 'self'; script-src 'self' 'nonce-${nonce}'; object-src 'none'`,
+      );
+      next();
+    });
+
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/pages/api/rateLimit.ts
+++ b/src/pages/api/rateLimit.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from 'express';
+
+type Bucket = {
+  tokens: number;
+  last: number;
+};
+
+export class TokenBucket {
+  private buckets = new Map<string, Bucket>();
+
+  constructor(private tokensPerInterval: number, private interval: number) {}
+
+  consume(key: string): boolean {
+    const now = Date.now();
+    const bucket = this.buckets.get(key) || { tokens: this.tokensPerInterval, last: now };
+    const elapsed = now - bucket.last;
+    const refill = (elapsed / this.interval) * this.tokensPerInterval;
+    bucket.tokens = Math.min(this.tokensPerInterval, bucket.tokens + refill);
+    bucket.last = now;
+
+    if (bucket.tokens < 1) {
+      this.buckets.set(key, bucket);
+      return false;
+    }
+
+    bucket.tokens -= 1;
+    this.buckets.set(key, bucket);
+    return true;
+  }
+}
+
+export const rateLimit = (bucket: TokenBucket) => (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const key = req.ip;
+  if (!bucket.consume(key)) {
+    res.status(429).send('Too Many Requests');
+    return;
+  }
+  next();
+};

--- a/tests/modules/Consent.test.ts
+++ b/tests/modules/Consent.test.ts
@@ -1,0 +1,26 @@
+import Consent from '../../src/modules/privacy/consent';
+
+describe('Consent module', () => {
+  beforeEach(() => {
+    (global as any).document = { cookie: '' };
+    (global as any).navigator = {};
+    (global as any).window = {};
+  });
+
+  it('detects consent via cookie', () => {
+    (global as any).document.cookie = 'cookie_consent=1';
+    expect(Consent.hasConsent()).toBe(true);
+  });
+
+  it('detects do not track', () => {
+    (global as any).navigator.doNotTrack = '1';
+    expect(Consent.isDoNotTrack()).toBe(true);
+  });
+
+  it('allows cookies only when consented and DNT disabled', () => {
+    (global as any).document.cookie = 'cookie_consent=1';
+    expect(Consent.canUseCookies()).toBe(true);
+    (global as any).navigator.doNotTrack = '1';
+    expect(Consent.canUseCookies()).toBe(false);
+  });
+});

--- a/tests/pages/api/RateLimiter.test.ts
+++ b/tests/pages/api/RateLimiter.test.ts
@@ -1,0 +1,20 @@
+import { TokenBucket } from '../../../src/pages/api/rateLimit';
+
+describe('TokenBucket rate limiter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('limits requests and refills tokens', () => {
+    const limiter = new TokenBucket(2, 1000);
+    expect(limiter.consume('ip')).toBe(true);
+    expect(limiter.consume('ip')).toBe(true);
+    expect(limiter.consume('ip')).toBe(false);
+    jest.advanceTimersByTime(1000);
+    expect(limiter.consume('ip')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- apply Content-Security-Policy headers with per-request nonce
- add cookie consent and Do Not Track detection utility
- introduce token-bucket rate limiter middleware for API endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2a4345c8328b549a598b78a2a51