### PR TITLE
feat: add semantic theme tokens and playground

### DIFF
--- a/src/pages/config/styles/global.scss
+++ b/src/pages/config/styles/global.scss
@@ -1,8 +1,9 @@
 :root {
-  --primary: #232931;
-  --secondary: #393e46;
-  --active: #4ecca3;
-  --background: #eee;
+  --surface: #232931;
+  --overlay: #2f343d;
+  --border: #4b5563;
+  --muted: #9ca3af;
+  --brand: #4ecca3;
 }
 
 * {
@@ -10,21 +11,21 @@
 }
 
 html {
-  background-color: var(--primary);
+  background-color: var(--surface);
 }
 
 body {
   font-family: JetBrainsMono, monospace;
   font-size: 13px;
   line-height: 1.2;
-  color: #fff;
+  color: var(--muted);
 }
 
 input {
-  border: 0;
+  border: 1px solid var(--border);
   outline: 0;
   padding: 7px 10px;
-  background-color: #393e46;
+  background-color: var(--overlay);
   border-radius: 5px;
-  color: #fff;
+  color: var(--brand);
 }

--- a/src/pages/theme-playground.tsx
+++ b/src/pages/theme-playground.tsx
@@ -1,0 +1,49 @@
+import { applyTheme, tokens, Theme, TokenName } from '../styles/tokens';
+
+// start with light theme
+let current: Theme = 'light';
+applyTheme(current);
+
+const root = document.createElement('div');
+document.body.appendChild(root);
+
+const toggle = document.createElement('button');
+toggle.textContent = 'Toggle theme';
+
+toggle.addEventListener('click', () => {
+  current = current === 'light' ? 'dark' : 'light';
+  applyTheme(current);
+  render();
+});
+
+const list = document.createElement('div');
+root.appendChild(toggle);
+root.appendChild(list);
+
+function render() {
+  list.innerHTML = '';
+  const set = tokens[current];
+  (Object.keys(set) as TokenName[]).forEach((name) => {
+    const value = set[name];
+    const item = document.createElement('div');
+    item.style.display = 'flex';
+    item.style.alignItems = 'center';
+    item.style.marginBottom = '8px';
+
+    const swatch = document.createElement('span');
+    swatch.style.width = '40px';
+    swatch.style.height = '20px';
+    swatch.style.marginRight = '8px';
+    swatch.style.background = value;
+    swatch.style.border = `1px solid ${set.border}`;
+
+    const label = document.createElement('code');
+    label.textContent = `${name}: ${value}`;
+
+    item.appendChild(swatch);
+    item.appendChild(label);
+    list.appendChild(item);
+  });
+}
+
+render();

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,0 +1,76 @@
+export type TokenName = 'surface' | 'overlay' | 'border' | 'muted' | 'brand';
+
+export type Theme = 'light' | 'dark';
+
+export interface TokenSet {
+  surface: string;
+  overlay: string;
+  border: string;
+  muted: string;
+  brand: string;
+}
+
+export const tokens: Record<Theme, TokenSet> = {
+  light: {
+    surface: '#ffffff',
+    overlay: '#f8f9fa',
+    border: '#e2e8f0',
+    muted: '#6b7280',
+    brand: '#047857',
+  },
+  dark: {
+    surface: '#232931',
+    overlay: '#2f343d',
+    border: '#4b5563',
+    muted: '#9ca3af',
+    brand: '#4ecca3',
+  },
+};
+
+function luminance(hex: string): number {
+  const value = hex.replace('#', '');
+  const r = parseInt(value.substring(0, 2), 16) / 255;
+  const g = parseInt(value.substring(2, 4), 16) / 255;
+  const b = parseInt(value.substring(4, 6), 16) / 255;
+
+  const [rr, gg, bb] = [r, g, b].map((v) => (
+    v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4
+  ));
+
+  return 0.2126 * rr + 0.7152 * gg + 0.0722 * bb;
+}
+
+function contrast(a: string, b: string): number {
+  let la = luminance(a);
+  let lb = luminance(b);
+  if (la < lb) {
+    [la, lb] = [lb, la];
+  }
+  return (la + 0.05) / (lb + 0.05);
+}
+
+function validateContrast(set: TokenSet): void {
+  const pairs: [TokenName, TokenName][] = [
+    ['surface', 'brand'],
+    ['surface', 'muted'],
+    ['overlay', 'brand'],
+    ['overlay', 'muted'],
+  ];
+
+  pairs.forEach(([bg, fg]) => {
+    const ratio = contrast(set[bg], set[fg]);
+    if (ratio < 4.5) {
+      // eslint-disable-next-line no-console
+      console.warn(`Low contrast between ${bg} and ${fg}: ${ratio.toFixed(2)}`);
+    }
+  });
+}
+
+export function applyTheme(theme: Theme): void {
+  const set = tokens[theme];
+  const root = document.documentElement;
+  (Object.keys(set) as TokenName[]).forEach((key) => {
+    root.style.setProperty(`--${key}`, set[key]);
+  });
+  validateContrast(set);
+}

--- a/src/templates/default/styles/footer.scss
+++ b/src/templates/default/styles/footer.scss
@@ -3,5 +3,5 @@ footer {
   text-align: center;
   font-size: .6rem;
   letter-spacing: 2px;
-  color: #b1b1b1;
+  color: var(--muted);
 }

--- a/src/templates/default/styles/helper.scss
+++ b/src/templates/default/styles/helper.scss
@@ -39,7 +39,7 @@
     position: absolute;
     top: 50%;
     max-width: calc(50% - (50px / 2));
-    border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid var(--border);
   }
   &::before {
     right: calc(50% + (50px / 2));
@@ -53,10 +53,10 @@
 
 .btn-more {
   margin: 0;
-  border: 1px solid #e5e5e5;
+  border: 1px solid var(--border);
   overflow: visible;
   font: inherit;
-  color: #333;
+  color: var(--muted);
   border-radius: 0;
   display: inline-block;
   box-sizing: border-box;
@@ -73,7 +73,7 @@
   transition-property: color,background-color,border-color;
   &:hover {
     background-color: transparent;
-    color: #333;
-    border-color: #b2b2b2;
+    color: var(--muted);
+    border-color: var(--border);
   }
 }


### PR DESCRIPTION
## Summary
- add theme token definitions for light and dark palettes with contrast validation
- use semantic tokens in global, footer, and helper styles
- add theme playground page to inspect tokens and toggle themes

## Testing
- `npm run lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2a6d7e88328a777d7c6be150129