### PR TITLE
Add survey widget, hotspot tracking, and changelog viewer

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!changelog.md

--- a/data/changelog.md
+++ b/data/changelog.md
@@ -1,0 +1,2 @@
+## v1.0.0
+- Initial release of changelog viewer

--- a/src/modules/changelog/Viewer.ts
+++ b/src/modules/changelog/Viewer.ts
@@ -1,0 +1,87 @@
+export default class ChangelogViewer {
+  private url = '/data/changelog.md';
+
+  private storageKey = 'changelog-last';
+
+  public async init(): Promise<void> {
+    try {
+      const response = await fetch(this.url);
+      if (!response.ok) {
+        return;
+      }
+      const text = await response.text();
+      const last = localStorage.getItem(this.storageKey);
+      if (last === text) {
+        return;
+      }
+      this.render(text);
+      localStorage.setItem(this.storageKey, text);
+    } catch {
+      // ignore
+    }
+  }
+
+  private render(markdown: string): void {
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.right = '0';
+    overlay.style.bottom = '0';
+    overlay.style.background = 'rgba(0, 0, 0, 0.5)';
+    overlay.style.overflow = 'auto';
+    overlay.style.zIndex = '10000';
+
+    const box = document.createElement('div');
+    box.style.background = '#fff';
+    box.style.margin = '5% auto';
+    box.style.padding = '20px';
+    box.style.maxWidth = '600px';
+
+    const close = document.createElement('button');
+    close.textContent = 'Close';
+    close.addEventListener('click', () => overlay.remove());
+
+    box.innerHTML = this.parseMarkdown(markdown);
+    box.appendChild(close);
+    overlay.appendChild(box);
+
+    document.body.appendChild(overlay);
+  }
+
+  private parseMarkdown(md: string): string {
+    const lines = md.split('\n');
+    let html = '';
+    let inList = false;
+    lines.forEach((line) => {
+      if (line.startsWith('## ')) {
+        if (inList) {
+          html += '</ul>';
+          inList = false;
+        }
+        html += `<h2>${line.substring(3)}</h2>`;
+      } else if (line.startsWith('- ')) {
+        if (!inList) {
+          html += '<ul>';
+          inList = true;
+        }
+        html += `<li>${line.substring(2)}</li>`;
+      } else if (line.trim() === '') {
+        if (inList) {
+          html += '</ul>';
+          inList = false;
+        }
+      } else {
+        if (inList) {
+          html += '</ul>';
+          inList = false;
+        }
+        html += `<p>${line}</p>`;
+      }
+    });
+    if (inList) {
+      html += '</ul>';
+    }
+    return html;
+  }
+}

--- a/src/modules/feedback/Survey.tsx
+++ b/src/modules/feedback/Survey.tsx
@@ -1,0 +1,72 @@
+export interface SurveyResponse {
+  rating: number;
+  comment: string;
+  timestamp: number;
+}
+
+export default class Survey {
+  private container: HTMLDivElement;
+
+  private selectedRating: number | null = null;
+
+  private storageKey = 'feedback-survey';
+
+  constructor() {
+    this.container = document.createElement('div');
+    this.container.style.position = 'fixed';
+    this.container.style.bottom = '10px';
+    this.container.style.right = '10px';
+    this.container.style.backgroundColor = '#fff';
+    this.container.style.border = '1px solid #ccc';
+    this.container.style.padding = '10px';
+    this.container.style.zIndex = '9999';
+
+    const title = document.createElement('p');
+    title.textContent = 'How likely are you to recommend us?';
+    this.container.appendChild(title);
+
+    const ratingContainer = document.createElement('div');
+    ratingContainer.style.display = 'flex';
+    ratingContainer.style.gap = '4px';
+
+    for (let i = 0; i <= 10; i += 1) {
+      const btn = document.createElement('button');
+      btn.textContent = i.toString();
+      btn.addEventListener('click', () => {
+        this.selectedRating = i;
+      });
+      ratingContainer.appendChild(btn);
+    }
+    this.container.appendChild(ratingContainer);
+
+    const textarea = document.createElement('textarea');
+    textarea.placeholder = 'Additional feedback';
+    textarea.style.display = 'block';
+    textarea.style.marginTop = '8px';
+    this.container.appendChild(textarea);
+
+    const submit = document.createElement('button');
+    submit.textContent = 'Submit';
+    submit.style.display = 'block';
+    submit.style.marginTop = '8px';
+    submit.addEventListener('click', () => {
+      if (this.selectedRating === null) {
+        return;
+      }
+      this.saveResponse(this.selectedRating, textarea.value);
+      this.container.remove();
+    });
+    this.container.appendChild(submit);
+  }
+
+  public mount(): void {
+    document.body.appendChild(this.container);
+  }
+
+  private saveResponse(rating: number, comment: string): void {
+    const store = localStorage.getItem(this.storageKey);
+    const data: SurveyResponse[] = store ? JSON.parse(store) : [];
+    data.push({ rating, comment, timestamp: Date.now() });
+    localStorage.setItem(this.storageKey, JSON.stringify(data));
+  }
+}

--- a/src/modules/feedback/hotspot.ts
+++ b/src/modules/feedback/hotspot.ts
@@ -1,0 +1,53 @@
+export interface HotspotMetric {
+  x: number;
+  y: number;
+  count: number;
+}
+
+const storageKey = 'feedback-hotspots';
+let timer: number | null = null;
+let lastX = 0;
+let lastY = 0;
+
+function load(): HotspotMetric[] {
+  const data = localStorage.getItem(storageKey);
+  return data ? JSON.parse(data) : [];
+}
+
+function save(metrics: HotspotMetric[]): void {
+  localStorage.setItem(storageKey, JSON.stringify(metrics));
+}
+
+function record(x: number, y: number): void {
+  const metrics = load();
+  const item = metrics.find((m) => m.x === x && m.y === y);
+  if (item) {
+    item.count += 1;
+  } else {
+    metrics.push({ x, y, count: 1 });
+  }
+  save(metrics);
+}
+
+export function startHotspotTracking(): void {
+  document.addEventListener('mousemove', (e) => {
+    lastX = Math.round(e.clientX);
+    lastY = Math.round(e.clientY);
+    if (timer) {
+      window.clearTimeout(timer);
+    }
+    timer = window.setTimeout(() => {
+      record(lastX, lastY);
+    }, 3000);
+  });
+
+  document.addEventListener('click', () => {
+    if (timer) {
+      window.clearTimeout(timer);
+    }
+  });
+}
+
+export function loadHotspots(): HotspotMetric[] {
+  return load();
+}

--- a/src/pages/feedback-dashboard.tsx
+++ b/src/pages/feedback-dashboard.tsx
@@ -1,0 +1,41 @@
+import { SurveyResponse } from '../modules/feedback/Survey';
+import { HotspotMetric, loadHotspots } from '../modules/feedback/hotspot';
+
+function loadSurvey(): SurveyResponse[] {
+  const data = localStorage.getItem('feedback-survey');
+  return data ? JSON.parse(data) : [];
+}
+
+function renderSurvey(container: HTMLElement, surveys: SurveyResponse[]): void {
+  const title = document.createElement('h2');
+  title.textContent = 'Survey Responses';
+  container.appendChild(title);
+
+  const list = document.createElement('ul');
+  surveys.forEach((s) => {
+    const item = document.createElement('li');
+    item.textContent = `${s.rating}: ${s.comment}`;
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+}
+
+function renderHotspots(container: HTMLElement, hotspots: HotspotMetric[]): void {
+  const title = document.createElement('h2');
+  title.textContent = 'Hotspot Metrics';
+  container.appendChild(title);
+
+  const list = document.createElement('ul');
+  hotspots.forEach((h) => {
+    const item = document.createElement('li');
+    item.textContent = `(${h.x}, ${h.y}) => ${h.count}`;
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.body;
+  renderSurvey(root, loadSurvey());
+  renderHotspots(root, loadHotspots());
+});

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,17 @@
+import Survey from '../../../modules/feedback/Survey.tsx';
+import { startHotspotTracking } from '../../../modules/feedback/hotspot';
+import ChangelogViewer from '../../../modules/changelog/Viewer';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });
   }
+
+  const survey = new Survey();
+  survey.mount();
+  startHotspotTracking();
+  const changelog = new ChangelogViewer();
+  changelog.init();
 })();


### PR DESCRIPTION
## Summary
- add survey widget that stores NPS rating and free-form feedback
- track zero-click hotspots and expose metrics on feedback dashboard
- show changelog on deploy by reading data/changelog.md

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2a802048328947f40a1e7ebfe7f