### PR TITLE
feat: add capability dialog and status bar

### DIFF
--- a/src/modules/capabilities/Dialog.tsx
+++ b/src/modules/capabilities/Dialog.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from 'react';
+
+interface CapabilityDialogProps {
+  capability: 'notifications' | 'clipboard';
+  onGranted?: () => void;
+  onDenied?: () => void;
+}
+
+/**
+ * A small dialog that requests the user to grant access to a browser
+ * capability such as Notifications or the Clipboard. The component provides
+ * context on why the permission is needed and reports the result through the
+ * provided callbacks.
+ */
+const CapabilityDialog: React.FC<CapabilityDialogProps> = ({
+  capability,
+  onGranted,
+  onDenied,
+}) => {
+  const requestPermission = useCallback(async () => {
+    try {
+      if (capability === 'notifications') {
+        if (!('Notification' in window)) {
+          onDenied?.();
+          return;
+        }
+
+        const permission = await Notification.requestPermission();
+        if (permission === 'granted') {
+          onGranted?.();
+        } else {
+          onDenied?.();
+        }
+      } else {
+        if (!navigator.clipboard) {
+          onDenied?.();
+          return;
+        }
+
+        await navigator.clipboard.writeText('');
+        onGranted?.();
+      }
+    } catch {
+      onDenied?.();
+    }
+  }, [capability, onGranted, onDenied]);
+
+  const contextMessage = capability === 'notifications'
+    ? 'This feature requires permission to send you notifications.'
+    : 'This feature requires access to your clipboard for copy and paste.';
+
+  return (
+    <div role="dialog" aria-modal="true" className="capability-dialog">
+      <p>{contextMessage}</p>
+      <button type="button" onClick={requestPermission}>
+        Allow
+      </button>
+    </div>
+  );
+};
+
+export default CapabilityDialog;

--- a/src/modules/capabilities/Fallback.tsx
+++ b/src/modules/capabilities/Fallback.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface FallbackProps {
+  capability: 'notifications' | 'clipboard';
+}
+
+/**
+ * Displays a simple message when a required capability is not supported by the
+ * current environment. Using a dedicated component ensures that core flows can
+ * continue even if optional features are unavailable.
+ */
+const CapabilityFallback: React.FC<FallbackProps> = ({ capability }) => (
+  <div className="capability-fallback">
+    {capability} capability is not supported in this browser.
+  </div>
+);
+
+export default CapabilityFallback;

--- a/src/modules/statusbar/StatusBar.tsx
+++ b/src/modules/statusbar/StatusBar.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Displays an OS-style status bar with information about caps lock state,
+ * network connectivity and available storage. All features degrade gracefully
+ * when the relevant APIs are not available.
+ */
+const StatusBar: React.FC = () => {
+  const [capsLock, setCapsLock] = useState<boolean | null>(null);
+  const [online, setOnline] = useState<boolean>(navigator.onLine);
+  const [storage, setStorage] = useState<string>('');
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      setCapsLock(e.getModifierState('CapsLock'));
+    };
+
+    window.addEventListener('keydown', handleKey);
+    window.addEventListener('keyup', handleKey);
+
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    if (navigator.storage && navigator.storage.estimate) {
+      navigator.storage.estimate().then(({ quota, usage }) => {
+        if (quota && usage !== undefined) {
+          const percent = ((usage / quota) * 100).toFixed(0);
+          setStorage(`${percent}% used`);
+        }
+      });
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      window.removeEventListener('keyup', handleKey);
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  let capsLabel = 'N/A';
+  if (capsLock !== null) {
+    capsLabel = capsLock ? 'ON' : 'off';
+  }
+
+  return (
+    <div className="status-bar">
+      <span className="caps-lock">Caps: {capsLabel}</span>
+      <span className="connection">{online ? 'Online' : 'Offline'}</span>
+      <span className="storage">{storage || 'Storage N/A'}</span>
+    </div>
+  );
+};
+
+export default StatusBar;


### PR DESCRIPTION
## Summary
- add dialog for requesting notification or clipboard permission
- add status bar for caps lock, connectivity, and storage
- handle missing browser capabilities with fallback messaging

## Testing
- `npx eslint --ext .js,.ts,.tsx . && echo 'lint ok'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2a90870832895f3ff2c2aeebaee