### PR TITLE
feat: add experiment flag utility and dashboard

### DIFF
--- a/src/pages/experiments.tsx
+++ b/src/pages/experiments.tsx
@@ -1,0 +1,38 @@
+import { getExperimentResults, ExperimentResult } from '../utils/flags';
+
+function toCSV(data: ExperimentResult[]): string {
+  const header = 'name,variant,timestamp';
+  const rows = data.map((r) => `${r.name},${r.variant},${r.timestamp}`);
+  return [header, ...rows].join('\n');
+}
+
+function render(): void {
+  const root = document.getElementById('experiments') || document.body;
+  const data = getExperimentResults();
+
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  thead.innerHTML = '<tr><th>Experiment</th><th>Variant</th><th>Timestamp</th></tr>';
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  data.forEach((r) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.name}</td><td>${r.variant}</td><td>${r.timestamp}</td>`;
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  root.appendChild(table);
+
+  const button = document.createElement('button');
+  button.textContent = 'Export CSV';
+  button.addEventListener('click', () => {
+    const csv = toCSV(data);
+    const link = document.createElement('a');
+    link.setAttribute('href', `data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`);
+    link.setAttribute('download', 'experiments.csv');
+    link.click();
+  });
+  root.appendChild(button);
+}
+
+document.addEventListener('DOMContentLoaded', render);

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -1,0 +1,112 @@
+
+export type Variant = 'A' | 'B';
+
+interface ExperimentResult {
+  name: string;
+  variant: Variant;
+  timestamp: string;
+}
+
+const SECRET = 'gportfolio-flag-secret';
+const STORAGE_KEY = 'experiments';
+
+function sign(value: string): string {
+  let hash = 0;
+  const str = `${value}${SECRET}`;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash.toString(16);
+}
+
+function parseCookies(): Record<string, string> {
+  if (typeof document === 'undefined') {
+    return {};
+  }
+  return document.cookie.split(';').reduce<Record<string, string>>((acc, part) => {
+    const [k, v] = part.split('=');
+    if (k && v) {
+      acc[k.trim()] = decodeURIComponent(v.trim());
+    }
+    return acc;
+  }, {});
+}
+
+function setCookie(name: string, value: string, days = 365): void {
+  if (typeof document === 'undefined') return;
+  const date = new Date();
+  date.setTime(date.getTime() + days * 864e5);
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${date.toUTCString()}; path=/`;
+}
+
+function getCookie(name: string): string | undefined {
+  return parseCookies()[name];
+}
+
+function setSignedCookie(name: string, value: string): void {
+  const signature = sign(value);
+  setCookie(name, `${value}.${signature}`);
+}
+
+function getSignedCookie(name: string): string | undefined {
+  const raw = getCookie(name);
+  if (!raw) return undefined;
+  const [value, signature] = raw.split('.');
+  return signature === sign(value) ? value : undefined;
+}
+
+export function getFlag(name: string): string | undefined {
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has(name)) {
+      const value = params.get(name)!;
+      setCookie(name, value);
+      return value;
+    }
+  }
+  return getCookie(name);
+}
+
+export function getABVariant(name: string): Variant {
+  const flag = `ab_${name}`;
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const paramVariant = params.get(flag);
+    if (paramVariant === 'A' || paramVariant === 'B') {
+      setSignedCookie(flag, paramVariant);
+      return paramVariant;
+    }
+  }
+  const cookieVariant = getSignedCookie(flag);
+  if (cookieVariant === 'A' || cookieVariant === 'B') {
+    return cookieVariant;
+  }
+  const variant: Variant = Math.random() < 0.5 ? 'A' : 'B';
+  setSignedCookie(flag, variant);
+  return variant;
+}
+
+export function recordExperiment(name: string, variant: Variant): void {
+  if (typeof localStorage === 'undefined') return;
+  const list = getExperimentResults();
+  list.push({ name, variant, timestamp: new Date().toISOString() });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+}
+
+export function getExperimentResults(): ExperimentResult[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ExperimentResult[]) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+export function clearExperimentResults(): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export type { ExperimentResult };

--- a/tests/utils/flags.test.ts
+++ b/tests/utils/flags.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getFlag, getABVariant, recordExperiment, getExperimentResults, clearExperimentResults } from '../../src/utils/flags';
+
+describe('flags', () => {
+  beforeEach(() => {
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = `${c.replace(/^ +/, '').split('=')[0]}=;expires=${new Date(0).toUTCString()};path=/`;
+    });
+    clearExperimentResults();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('reads flag from query params and stores cookie', () => {
+    window.history.replaceState({}, '', '/?foo=bar');
+    const value = getFlag('foo');
+    expect(value).toBe('bar');
+    expect(document.cookie).toContain('foo=bar');
+  });
+
+  it('assigns A/B variant in signed cookie', () => {
+    getABVariant('test');
+    const match = document.cookie.match(/ab_test=([^;]+)/);
+    expect(match).not.toBeNull();
+    const original = match![1];
+    // tamper with cookie
+    document.cookie = `ab_test=${original.split('.')[0]}.tampered`;
+    getABVariant('test');
+    const updated = document.cookie.match(/ab_test=([^;]+)/)![1];
+    expect(updated).not.toBe(`${original.split('.')[0]}.tampered`);
+  });
+
+  it('records experiment results', () => {
+    recordExperiment('exp', 'A');
+    const results = getExperimentResults();
+    expect(results.length).toBe(1);
+    expect(results[0].name).toBe('exp');
+  });
+});


### PR DESCRIPTION
## Summary
- add lightweight flag and experiment utilities
- provide dashboard page to view results and export CSV
- cover experiment utilities with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2ad4ec4832888892b9b33bf502e