### PR TITLE
feat: add request helpers and offline sync

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,31 @@
+export type StateEntry<T> = {
+  value: T;
+  tags: Set<string>;
+};
+
+export default class Store {
+  private data: Map<string, StateEntry<any>> = new Map();
+
+  public get<T>(key: string): T | undefined {
+    const entry = this.data.get(key);
+    return entry ? entry.value as T : undefined;
+  }
+
+  public set<T>(key: string, value: T, tags: string[] = []): void {
+    this.data.set(key, { value, tags: new Set(tags) });
+  }
+
+  public invalidate(tags: string[]): void {
+    if (!tags.length) {
+      return;
+    }
+
+    this.data.forEach((entry, key) => {
+      if (tags.some((tag) => entry.tags.has(tag))) {
+        this.data.delete(key);
+      }
+    });
+  }
+}
+
+export const store = new Store();

--- a/src/utils/network/request.ts
+++ b/src/utils/network/request.ts
@@ -1,0 +1,77 @@
+import { store } from '../../state/store';
+
+export interface RequestOptions {
+  timeout?: number;
+  retries?: number;
+  cacheKey?: string;
+  tags?: string[];
+  invalidateTags?: string[];
+  signal?: AbortSignal;
+}
+
+export type RequestExecutor<T> = (signal: AbortSignal) => Promise<T>;
+
+export default async function request<T>(
+  executor: RequestExecutor<T>,
+  options: RequestOptions = {},
+): Promise<T> {
+  const {
+    timeout,
+    retries = 0,
+    cacheKey,
+    tags = [],
+    invalidateTags = [],
+    signal,
+  } = options;
+
+  if (cacheKey) {
+    const cached = store.get<T>(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  let attempt = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort();
+      } else {
+        signal.addEventListener('abort', () => controller.abort());
+      }
+    }
+
+    if (timeout !== undefined) {
+      timer = setTimeout(() => controller.abort(), timeout);
+    }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await executor(controller.signal);
+      if (cacheKey) {
+        store.set(cacheKey, result, tags);
+      }
+      if (invalidateTags.length) {
+        store.invalidate(invalidateTags);
+      }
+      return result;
+    } catch (err) {
+      if (controller.signal.aborted && attempt >= retries) {
+        throw err;
+      }
+      if (attempt >= retries) {
+        throw err;
+      }
+      attempt += 1;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}

--- a/src/utils/offlineSync.ts
+++ b/src/utils/offlineSync.ts
@@ -1,0 +1,81 @@
+export interface Draft<T = any> {
+  id: string;
+  data: T;
+}
+
+export default class OfflineSync<T = any> {
+  private dbName = 'drafts';
+
+  private storeName = 'drafts';
+
+  private send: (draft: Draft<T>) => Promise<any>;
+
+  private dbPromise: Promise<IDBDatabase>;
+
+  constructor(send: (draft: Draft<T>) => Promise<any>) {
+    this.send = send;
+    this.dbPromise = this.openDB();
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', () => {
+        this.sync();
+      });
+    }
+  }
+
+  private openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(this.dbName, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          db.createObjectStore(this.storeName, { keyPath: 'id' });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  public async saveDraft(id: string, data: T): Promise<void> {
+    const db = await this.dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readwrite');
+      tx.objectStore(this.storeName).put({ id, data });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  private async getAllDrafts(): Promise<Draft<T>[]> {
+    const db = await this.dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readonly');
+      const req = tx.objectStore(this.storeName).getAll();
+      req.onsuccess = () => resolve(req.result as Draft<T>[]);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async removeDraft(id: string): Promise<void> {
+    const db = await this.dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(this.storeName, 'readwrite');
+      tx.objectStore(this.storeName).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  public async sync(): Promise<void> {
+    const drafts = await this.getAllDrafts();
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const draft of drafts) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.send(draft);
+      // eslint-disable-next-line no-await-in-loop
+      await this.removeDraft(draft.id);
+    }
+  }
+}

--- a/tests/utils/network/request.test.ts
+++ b/tests/utils/network/request.test.ts
@@ -1,0 +1,48 @@
+import request from '../../../src/utils/network/request';
+
+jest.useFakeTimers();
+
+describe('request helper', () => {
+  it('retries failed requests', async () => {
+    let attempts = 0;
+    const executor = jest.fn().mockImplementation(() => {
+      attempts += 1;
+      if (attempts < 2) {
+        return Promise.reject(new Error('fail'));
+      }
+      return Promise.resolve('ok');
+    });
+
+    const result = await request(executor, { retries: 1 });
+    expect(result).toBe('ok');
+    expect(executor).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts after timeout', async () => {
+    const executor = jest.fn().mockImplementation(
+      (signal: AbortSignal) => new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')));
+      }),
+    );
+
+    const promise = request(executor, { timeout: 10 });
+
+    jest.advanceTimersByTime(20);
+
+    await expect(promise).rejects.toThrow('aborted');
+  });
+
+  it('supports external abort', async () => {
+    const controller = new AbortController();
+    const executor = jest.fn().mockImplementation(
+      (signal: AbortSignal) => new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')));
+      }),
+    );
+
+    const promise = request(executor, { signal: controller.signal });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow('aborted');
+  });
+});


### PR DESCRIPTION
## Summary
- add request utility with timeout, abort, retry, and cache tagging
- implement tag-aware state store for cache invalidation
- store drafts in IndexedDB and sync when online

## Testing
- `npx eslint --ext .ts src tests`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b3d2ae95588328913be3358fafc345