### PR TITLE
Add SSE progress endpoint and client controls

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,45 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import {
+  Application,
+  Request,
+  Response,
+} from 'express';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    if (process.env.RUNTIME === 'nodejs') {
+      app.get('/api/progress', (req: Request, res: Response) => {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+        res.flushHeaders();
+        res.write('retry: 3000\n\n');
+
+        const sendHeartbeat = () => {
+          res.write(`event: heartbeat\nid: ${Date.now()}\ndata: \n\n`);
+        };
+
+        const heartbeatInterval = setInterval(sendHeartbeat, 15000);
+        sendHeartbeat();
+
+        let progress = 0;
+        const progressInterval = setInterval(() => {
+          progress += 1;
+          res.write(`id: ${progress}\ndata: ${progress}\n\n`);
+          if (progress >= 100) {
+            clearInterval(progressInterval);
+            clearInterval(heartbeatInterval);
+            res.end();
+          }
+        }, 1000);
+
+        req.on('close', () => {
+          clearInterval(progressInterval);
+          clearInterval(heartbeatInterval);
+        });
+      });
+    }
   }
 }

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -4,4 +4,71 @@
       navigator.serviceWorker.register('/sw.js');
     });
   }
+
+  const initProgress = () => {
+    const container = document.createElement('div');
+    const progress = document.createElement('progress');
+    progress.max = 100;
+    progress.value = 0;
+
+    const pause = document.createElement('button');
+    pause.textContent = 'Pause';
+    const resume = document.createElement('button');
+    resume.textContent = 'Resume';
+    const cancel = document.createElement('button');
+    cancel.textContent = 'Cancel';
+
+    const consoleEl = document.createElement('pre');
+    consoleEl.id = 'console';
+
+    container.appendChild(progress);
+    container.appendChild(pause);
+    container.appendChild(resume);
+    container.appendChild(cancel);
+    container.appendChild(consoleEl);
+    document.body.appendChild(container);
+
+    let source: EventSource | null = null;
+    let paused = false;
+
+    const connect = () => {
+      source = new EventSource('/api/progress');
+      source.onmessage = (e) => {
+        if (paused) return;
+        const val = Number(e.data);
+        if (!Number.isNaN(val)) {
+          progress.value = val;
+        }
+        consoleEl.textContent += `${e.data}\n`;
+      };
+      source.addEventListener('heartbeat', () => {
+        // keep connection alive
+      });
+      source.onerror = () => {
+        consoleEl.textContent += '\n[connection lost, retrying]\n';
+      };
+    };
+
+    connect();
+
+    pause.addEventListener('click', () => {
+      paused = true;
+    });
+    resume.addEventListener('click', () => {
+      if (!source) {
+        connect();
+      }
+      paused = false;
+    });
+    cancel.addEventListener('click', () => {
+      source?.close();
+      source = null;
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initProgress);
+  } else {
+    initProgress();
+  }
 })();


### PR DESCRIPTION
## Summary
- implement `/api/progress` SSE endpoint with heartbeat events and retry headers when running under Node
- add progress bar with cancel, pause and resume wired to the SSE stream
- stream text chunks to a console element with automatic reconnection notices

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3f0d8b88328bbe492a9b83dedb8