### PR TITLE
feat: add structured data and breadcrumbs

### DIFF
--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -1,0 +1,46 @@
+---
+title: Help
+faqs:
+  - question: "What is GPortfolio?"
+    answer: "An open source portfolio generator."
+  - question: "How to use this site?"
+    answer: "Configure and build."
+---
+
+# Help
+
+Welcome to the help page.
+
+<script id="faq-data" type="application/json">
+{
+  "faqs": [
+    {"question": "What is GPortfolio?", "answer": "An open source portfolio generator."},
+    {"question": "How to use this site?", "answer": "Configure and build."}
+  ]
+}
+</script>
+<script>
+(function () {
+  var el = document.getElementById('faq-data');
+  if (!el) return;
+  try {
+    var frontMatter = JSON.parse(el.textContent);
+    if (!frontMatter.faqs) return;
+    var schema = {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": frontMatter.faqs.map(function (faq) {
+        return {
+          "@type": "Question",
+          "name": faq.question,
+          "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+        };
+      })
+    };
+    var s = document.createElement('script');
+    s.type = 'application/ld+json';
+    s.text = JSON.stringify(schema);
+    document.head.appendChild(s);
+  } catch (e) {}
+})();
+</script>

--- a/src/templates/_common/templates/header/index.ejs
+++ b/src/templates/_common/templates/header/index.ejs
@@ -1,3 +1,77 @@
 <head>
     <%= require('./full.ejs')() %>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            var docEl = document.documentElement;
+
+            function appendJsonLd(attr) {
+                var data = docEl.getAttribute(attr);
+                if (!data) return;
+                try {
+                    var script = document.createElement('script');
+                    script.type = 'application/ld+json';
+                    script.text = data;
+                    document.head.appendChild(script);
+                } catch (e) {}
+            }
+
+            appendJsonLd('data-jsonld-website');
+
+            var path = window.location.pathname.replace(/\/$/, '');
+            var segments = path.split('/').filter(function (s) { return s; });
+            var breadcrumbItems = [];
+            if (segments.length) {
+                var nav = document.createElement('nav');
+                nav.setAttribute('aria-label', 'Breadcrumb');
+                var ol = document.createElement('ol');
+                nav.appendChild(ol);
+                var cumulative = '';
+                segments.forEach(function (seg, idx) {
+                    cumulative += '/' + seg;
+                    var li = document.createElement('li');
+                    var name = decodeURIComponent(seg);
+                    if (idx < segments.length - 1) {
+                        var a = document.createElement('a');
+                        a.href = cumulative;
+                        a.textContent = name;
+                        li.appendChild(a);
+                    } else {
+                        li.textContent = name;
+                    }
+                    ol.appendChild(li);
+                    breadcrumbItems.push({
+                        '@type': 'ListItem',
+                        position: idx + 1,
+                        name: name,
+                        item: cumulative,
+                    });
+                });
+                document.body.insertBefore(nav, document.body.firstChild);
+            }
+
+            var breadcrumbData = docEl.getAttribute('data-jsonld-breadcrumb');
+            if (breadcrumbData) {
+                try {
+                    var breadcrumbObj = JSON.parse(breadcrumbData);
+                    breadcrumbObj.itemListElement = breadcrumbItems;
+                    var breadcrumbScript = document.createElement('script');
+                    breadcrumbScript.type = 'application/ld+json';
+                    breadcrumbScript.text = JSON.stringify(breadcrumbObj);
+                    document.head.appendChild(breadcrumbScript);
+                } catch (e) {}
+            }
+
+            var articleData = docEl.getAttribute('data-jsonld-article');
+            if (articleData) {
+                try {
+                    var articleObj = JSON.parse(articleData);
+                    articleObj.headline = document.title;
+                    var articleScript = document.createElement('script');
+                    articleScript.type = 'application/ld+json';
+                    articleScript.text = JSON.stringify(articleObj);
+                    document.head.appendChild(articleScript);
+                } catch (e) {}
+            }
+        });
+    </script>
 </head>

--- a/src/templates/_common/templates/html-attributes.ejs
+++ b/src/templates/_common/templates/html-attributes.ejs
@@ -44,6 +44,32 @@ const app = di.get(TYPES.Application);
 
 const { config } = app;
 const lang = config.global.locale.split('_')[0];
+
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  url: app.url,
+  name: `${config.data.first_name} ${config.data.last_name}`.trim(),
+};
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [],
+};
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: '',
+};
+
+function escapeAttr(value) {
+  return value.replace(/"/g, '&quot;');
+}
 %>
 
 lang="<%= lang %>" data-template="<%= templateName %>" time-compiled="<%= Date.now() %>"
+data-jsonld-website="<%- escapeAttr(JSON.stringify(websiteJsonLd)) %>"
+data-jsonld-breadcrumb="<%- escapeAttr(JSON.stringify(breadcrumbJsonLd)) %>"
+data-jsonld-article="<%- escapeAttr(JSON.stringify(articleJsonLd)) %>"


### PR DESCRIPTION
## Summary
- add JSON-LD data attributes for WebSite, BreadcrumbList, and Article
- build runtime breadcrumbs and schema injection from URL segments
- add help page with FAQPage schema from front matter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3f19b248328879f13ae57661d57