### PR TITLE
feat: refine SEO meta and robots handling

### DIFF
--- a/public/robots.preview.txt
+++ b/public/robots.preview.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,32 @@
+import path from 'path';
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import {
+  Application,
+  NextFunction,
+  Request,
+  Response,
+} from 'express';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    const isPreview = () => process.env.VERCEL_ENV === 'preview' || process.env.NODE_ENV !== 'production';
+
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      const privateRoute = /^\/api\//.test(req.path) || /^\/private\//.test(req.path) || /^\/preview\//.test(req.path);
+
+      if (isPreview() || privateRoute) {
+        res.setHeader('X-Robots-Tag', 'noindex');
+      }
+
+      next();
+    });
+
+    app.get('/robots.txt', (req: Request, res: Response) => {
+      const fileName = isPreview() ? 'robots.preview.txt' : 'robots.txt';
+
+      res.sendFile(path.join(process.cwd(), 'public', fileName));
+    });
   }
 }

--- a/src/templates/_common/templates/header/full.ejs
+++ b/src/templates/_common/templates/header/full.ejs
@@ -1,2 +1,14 @@
+<%
+const { di } = require('../../../../di');
+const { TYPES } = require('../../../../types');
+
+/** @type {IApplication} */
+const app = di.get(TYPES.Application);
+
+const { config, url } = app;
+const hreflang = config.global.locale.replace('_', '-');
+%>
 <%= require('./basic.ejs')() %>
 <%= require('./opg.ejs')() %>
+<link rel="canonical" href="<%= url %>" />
+<link rel="alternate" href="<%= url %>" hreflang="<%= hreflang %>">


### PR DESCRIPTION
## Summary
- serve environment-specific robots.txt
- add canonical and hreflang links
- add X-Robots-Tag header for private/preview routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3f2f8fc8328a95b65592f416e7c