### PR TITLE
fix: adapt layout for safe areas and touch targets

### DIFF
--- a/src/templates/default/styles/footer.scss
+++ b/src/templates/default/styles/footer.scss
@@ -1,5 +1,6 @@
 footer {
   margin-bottom: 30px;
+  padding: 0 env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   text-align: center;
   font-size: .6rem;
   letter-spacing: 2px;

--- a/src/templates/default/styles/global.scss
+++ b/src/templates/default/styles/global.scss
@@ -8,6 +8,7 @@ body {
   font-weight: 400;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
+  min-height: 100dvh;
 }
 
 a {

--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -1,7 +1,8 @@
 .header {
   position: relative;
   min-height: 500px;
-  padding: 70px 20px;
+  padding: calc(70px + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right))
+           calc(70px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
   &__background {
     position: absolute;
     top: 0;
@@ -61,13 +62,13 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 35px;
-        height: 35px;
-        padding: 9px;
-        margin: 0 7px;
+        width: 44px;
+        height: 44px;
+        padding: 10px;
+        margin: 0 8px;
         color: #fff;
         transition: .2s;
-        min-width: 35px;
+        min-width: 44px;
         &:hover {
           background: rgba(0, 0, 0, .5);
           border-radius: 10px;


### PR DESCRIPTION
## Summary
- use `100dvh` for layout height
- pad header and footer with `env(safe-area-inset-*)`
- enlarge window control tap targets for better accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3f3b4b8832883beb393c1f984c5