### PR TITLE
perf: optimize font loading and early connections

### DIFF
--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -3,26 +3,11 @@
 <html lang="en">
 <head>
     <title>GPortfolio - Settings</title>
-    <style>
-    @font-face {
-        font-family: 'JetBrainsMono';
-        font-style: normal;
-        font-weight: normal;
-        src: url(<%= require('./fonts/JetBrainsMono-Regular.ttf').default %>)
-    }
-    @font-face {
-        font-family: 'JetBrainsMono';
-        font-style: normal;
-        font-weight: bold;
-        src: url(<%= require('./fonts/JetBrainsMono-Bold.ttf').default %>)
-    }
-    @font-face {
-        font-family: 'JetBrainsMono';
-        font-style: italic;
-        font-weight: normal;
-        src: url(<%= require('./fonts/JetBrainsMono-Italic.ttf').default %>)
-    }
-    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 </head>
 <body>
 <!--<section>-->

--- a/src/pages/config/styles/global.scss
+++ b/src/pages/config/styles/global.scss
@@ -14,7 +14,7 @@ html {
 }
 
 body {
-  font-family: JetBrainsMono, monospace;
+  font-family: 'JetBrains Mono', monospace;
   font-size: 13px;
   line-height: 1.2;
   color: #fff;

--- a/src/templates/_common/templates/html-attributes.ejs
+++ b/src/templates/_common/templates/html-attributes.ejs
@@ -44,6 +44,13 @@ const app = di.get(TYPES.Application);
 
 const { config } = app;
 const lang = config.global.locale.split('_')[0];
+
+const resourceHints = [
+  'https://fonts.googleapis.com',
+  'https://fonts.gstatic.com',
+];
+
+module.exports.hints = resourceHints;
 %>
 
 lang="<%= lang %>" data-template="<%= templateName %>" time-compiled="<%= Date.now() %>"

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -45,13 +45,15 @@ function generateRepositoriesHtml(repositories) {
 }
 %>
 
-<html <%= require('../_common/templates/html-attributes.ejs')({ templateName: 'default' }) %>>
+<% const htmlAttributes = require('../_common/templates/html-attributes.ejs'); %>
+<html <%= htmlAttributes({ templateName: 'default' }) %>>
 <head>
+  <% htmlAttributes.hints.forEach(origin => { %>
+    <link rel="preconnect" href="<%= origin %>">
+    <link rel="dns-prefetch" href="<%= origin %>">
+  <% }); %>
   <%= require('../_common/templates/header/full.ejs')() %>
   <style>
-    .avatar--image {
-      background: url(<%= resolveFile(config.data.avatar) %>);
-    }
     .background--image {
       background: url(<%= resolveFile(config.templates.default.configuration.background) %>);
     }
@@ -61,7 +63,7 @@ function generateRepositoriesHtml(repositories) {
 <header class="header">
   <div class="header__background background--image"></div>
   <div class="header__wrap">
-    <div class="header__wrap__image avatar--image"></div>
+    <img class="header__wrap__image" src="<%= resolveFile(config.data.avatar) %>" alt="<%= `${config.data.first_name} ${config.data.last_name}` %>" fetchpriority="high" />
     <h1 class="header__wrap__name"><%= `${config.data.first_name} ${config.data.last_name}` %></h1>
     <% if (config.data.position) { %>
       <span class="header__wrap__position"><%= config.data.position %></span>

--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -30,9 +30,8 @@
       height: 200px;
       margin: 0 auto;
       border-radius: 20px;
-      background-position: 50% 50%;
-      background-repeat: no-repeat;
-      background-size: cover;
+      display: block;
+      object-fit: cover;
     }
     &__name {
       margin: 35px 0 5px;


### PR DESCRIPTION
## Summary
- replace manual JetBrains Mono font-face with Google Fonts import in config page
- expose font resource hints and apply preconnect/dns-prefetch for third‑party origins
- prioritize avatar image loading via fetchpriority and simplify header styles

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3dd9939448328bbbd51ff9aaa953c