### PR TITLE
feat: improve security headers and integrity

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -21,6 +21,8 @@ export default class Application implements IApplication {
 
   private siteUrl: string;
 
+  public cspNonce = '';
+
   constructor(
   @inject(TYPES.UserData) userData: IConfig,
     @multiInject(TYPES.Services) services: IService[],
@@ -106,6 +108,10 @@ export default class Application implements IApplication {
       opg: {},
       pwa: null,
       meta: {},
+      features: {
+        sharedArrayBuffer: false,
+        wasm: false,
+      },
       www: {
         domain: '',
         path: '',

--- a/src/interfaces/IApplication.ts
+++ b/src/interfaces/IApplication.ts
@@ -7,4 +7,9 @@ export default interface IApplication {
   template: ITemplate
 
   url: string
+
+  /**
+   * Content Security Policy nonce for inline scripts.
+   */
+  cspNonce: string
 }

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -22,6 +22,10 @@ export interface IConfigGlobal {
   opg: object
   pwa: ManifestOptions | null
   meta: object
+  features: {
+    sharedArrayBuffer: boolean
+    wasm: boolean
+  }
   www: IConfigGlobalWww
 }
 

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,31 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import crypto from 'crypto';
+import { di } from '../../di';
+import { TYPES } from '../../types';
+import IApplication from '../../interfaces/IApplication';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    const application: IApplication = di.get(TYPES.Application);
+
+    app.use((req, res, next) => {
+      const nonce = crypto.randomBytes(16).toString('base64');
+      application.cspNonce = nonce;
+
+      res.setHeader('Content-Security-Policy', `script-src 'self' 'nonce-${nonce}'`);
+
+      const features = application.config.global.features;
+      if (features.sharedArrayBuffer || features.wasm) {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+      }
+
+      next();
+    });
+
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/templates/_common/templates/html-attributes.ejs
+++ b/src/templates/_common/templates/html-attributes.ejs
@@ -3,6 +3,8 @@
 
 const { di } = require('../../../di');
 const { TYPES } = require('../../../types');
+const crypto = require('crypto');
+const fs = require('fs');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
@@ -43,6 +45,26 @@ const app = di.get(TYPES.Application);
 
 
 const { config } = app;
+function generateIntegrity(file) {
+  try {
+    const content = fs.readFileSync(file);
+    return `sha384-${crypto.createHash('sha384').update(content).digest('base64')}`;
+  } catch (e) {
+    return '';
+  }
+}
+
+const meta = config.global.meta || {};
+const externalScripts = (meta.externalScripts || []).map((src) => {
+  const integrity = generateIntegrity(src);
+  return `<script src="${src}"${integrity ? ` integrity=\"${integrity}\" crossorigin=\"anonymous\"` : ''}></script>`;
+});
+const externalStyles = (meta.externalStyles || []).map((href) => {
+  const integrity = generateIntegrity(href);
+  return `<link rel="stylesheet" href="${href}"${integrity ? ` integrity=\"${integrity}\" crossorigin=\"anonymous\"` : ''}/>`;
+});
+app.externalScriptsTags = externalScripts.join('\n');
+app.externalStylesTags = externalStyles.join('\n');
 const lang = config.global.locale.split('_')[0];
 %>
 

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -46,9 +46,10 @@ function generateRepositoriesHtml(repositories) {
 %>
 
 <html <%= require('../_common/templates/html-attributes.ejs')({ templateName: 'default' }) %>>
-<head>
-  <%= require('../_common/templates/header/full.ejs')() %>
-  <style>
+  <head>
+    <%= require('../_common/templates/header/full.ejs')() %>
+    <%- app.externalStylesTags %>
+    <style>
     .avatar--image {
       background: url(<%= resolveFile(config.data.avatar) %>);
     }
@@ -56,8 +57,8 @@ function generateRepositoriesHtml(repositories) {
       background: url(<%= resolveFile(config.templates.default.configuration.background) %>);
     }
   </style>
-</head>
-<body>
+  </head>
+  <body>
 <header class="header">
   <div class="header__background background--image"></div>
   <div class="header__wrap">
@@ -110,8 +111,8 @@ function generateRepositoriesHtml(repositories) {
   }) %></span>
 </footer>
 
-<% if (canShowMoreRepositories) {%>
-<script type="text/javascript">
+  <% if (canShowMoreRepositories) {%>
+  <script nonce="<%= app.cspNonce %>" type="text/javascript">
 var repositories = <%= JSON.stringify(repositories.splice(repositoriesMore)) %>;
 
 window.addEventListener('DOMContentLoaded', function () {
@@ -136,7 +137,8 @@ function htmlToElements(html) {
 }
 
 <%= generateRepositoriesHtml.toString() %>
-</script>
-<% } %>
-</body>
-</html>
+  </script>
+  <% } %>
+  <%- app.externalScriptsTags %>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add SRI generation for external scripts/styles
- set COOP/COEP and CSP headers with nonce support
- embed CSP nonce in templates and expose external asset tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd9a882c8328ae325dc475732af4