### PR TITLE
feat: add draft preview handling

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,57 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import {
+  Application,
+  NextFunction,
+  Request,
+  Response,
+} from 'express';
 
 export default class Server {
+  private validatePreviewToken(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const token = req.query.preview as string;
+    const validToken = process.env.PREVIEW_TOKEN;
+
+    if (!validToken || token !== validToken) {
+      res.status(401).send('Invalid preview token');
+      return;
+    }
+
+    next();
+  }
+
+  private applyPreviewHeaders(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    res.set('X-Robots-Tag', 'noindex');
+
+    const originalSend = res.send.bind(res);
+    res.send = (body: any): Response => {
+      let html = body;
+      if (typeof html === 'string' && html.includes('<body')) {
+        const banner = '<div style="position:fixed;top:0;left:0;width:100%;background:#ffc;color:#000;text-align:center;padding:5px;z-index:9999;">Preview mode - do not share</div>';
+        html = html.replace('<body', `<body>${banner}`);
+      }
+      return originalSend(html);
+    };
+
+    next();
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    app.use(
+      '/draft',
+      this.validatePreviewToken.bind(this),
+      this.applyPreviewHeaders.bind(this),
+    );
+
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/pages/published.mdx
+++ b/src/pages/published.mdx
@@ -1,0 +1,8 @@
+---
+title: Sample Published
+state: published
+---
+
+# Sample Published
+
+Visible content.

--- a/src/pages/sample.mdx
+++ b/src/pages/sample.mdx
@@ -1,0 +1,8 @@
+---
+title: Sample Draft
+state: draft
+---
+
+# Sample Draft
+
+Content here.


### PR DESCRIPTION
## Summary
- validate preview tokens before serving draft pages
- mark draft pages with `X-Robots-Tag: noindex` and preview banner
- document MDX front matter states for draft and published posts

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3dd9bfa1083289cca738684451e32