### PR TITLE
Add fetch retry utility and tag-based caching

### DIFF
--- a/src/modules/server/RouteError.ts
+++ b/src/modules/server/RouteError.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface ErrorResponse {
+  status: number;
+  code: string;
+  message: string;
+}
+
+export default class RouteError extends Error {
+  public status: number;
+
+  public code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public toJSON(): ErrorResponse {
+    return {
+      status: this.status,
+      code: this.code,
+      message: this.message,
+    };
+  }
+}
+
+export function toErrorResponse(err: unknown): ErrorResponse {
+  if (err instanceof RouteError) {
+    return err.toJSON();
+  }
+
+  if (err && typeof err === 'object' && 'status' in err && 'code' in err && 'message' in err) {
+    const e = err as { status: number; code: string; message: string };
+    return { status: e.status, code: e.code, message: e.message };
+  }
+
+  return {
+    status: 500,
+    code: 'InternalError',
+    message: err instanceof Error ? err.message : 'Unknown error',
+  };
+}
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const response = toErrorResponse(err);
+  res.status(response.status).json(response);
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,6 +1,7 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import { errorHandler } from './RouteError';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,5 +10,7 @@ export default class Server {
     //   const response = await build();
     //   resp.json(response);
     // });
+
+    app.use(errorHandler);
   }
 }

--- a/src/utils/TagCache.ts
+++ b/src/utils/TagCache.ts
@@ -1,0 +1,40 @@
+export default class TagCache<T = any> {
+  private store: Map<string, { value: T; tags: Set<string> }> = new Map();
+
+  private tagMap: Map<string, Set<string>> = new Map();
+
+  public set(key: string, value: T, tags: string[] = []): void {
+    const tagSet = new Set(tags);
+    this.store.set(key, { value, tags: tagSet });
+
+    tags.forEach((tag) => {
+      if (!this.tagMap.has(tag)) {
+        this.tagMap.set(tag, new Set());
+      }
+      this.tagMap.get(tag)!.add(key);
+    });
+  }
+
+  public get(key: string): T | undefined {
+    const entry = this.store.get(key);
+    return entry ? entry.value : undefined;
+  }
+
+  public invalidateTags(tags: string[]): void {
+    tags.forEach((tag) => {
+      const keys = this.tagMap.get(tag);
+      if (!keys) {
+        return;
+      }
+      keys.forEach((key) => {
+        this.store.delete(key);
+      });
+      this.tagMap.delete(tag);
+    });
+  }
+
+  public clear(): void {
+    this.store.clear();
+    this.tagMap.clear();
+  }
+}

--- a/src/utils/fetchWithRetry.ts
+++ b/src/utils/fetchWithRetry.ts
@@ -1,0 +1,50 @@
+export interface FetchRetryOptions extends RequestInit {
+  retries?: number;
+  retryDelay?: number;
+  timeout?: number;
+}
+
+/* eslint-disable no-await-in-loop */
+export default async function fetchWithRetry(
+  url: string,
+  options: FetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    retries = 3,
+    retryDelay = 300,
+    timeout,
+    ...fetchOptions
+  } = options;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timer = timeout
+      ? setTimeout(() => controller.abort(), timeout)
+      : undefined;
+
+    try {
+      const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+
+      if (!response.ok && response.status >= 500 && attempt < retries) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      if (timer) clearTimeout(timer);
+
+      return response;
+    } catch (error) {
+      if (timer) clearTimeout(timer);
+
+      if (attempt >= retries) {
+        throw error;
+      }
+
+      const jitter = Math.random() * retryDelay;
+      const delay = retryDelay * (2 ** attempt) + jitter;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  // Should never reach here
+  throw new Error('Failed to fetch');
+}

--- a/tests/modules/RouteError.test.ts
+++ b/tests/modules/RouteError.test.ts
@@ -1,0 +1,30 @@
+import RouteError, { errorHandler } from '../../src/modules/server/RouteError';
+
+function createRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('RouteError', () => {
+  it('formats known errors', () => {
+    const err = new RouteError(404, 'NotFound', 'not found');
+    const res = createRes();
+
+    errorHandler(err, {} as any, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ status: 404, code: 'NotFound', message: 'not found' });
+  });
+
+  it('formats unknown errors', () => {
+    const err = new Error('boom');
+    const res = createRes();
+
+    errorHandler(err, {} as any, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ status: 500, code: 'InternalError', message: 'boom' });
+  });
+});

--- a/tests/utils/TagCache.test.ts
+++ b/tests/utils/TagCache.test.ts
@@ -1,0 +1,19 @@
+import TagCache from '../../src/utils/TagCache';
+
+describe('TagCache', () => {
+  it('stores and retrieves values', () => {
+    const cache = new TagCache<number>();
+    cache.set('a', 1, ['group1']);
+    expect(cache.get('a')).toBe(1);
+  });
+
+  it('invalidates by tag', () => {
+    const cache = new TagCache<number>();
+    cache.set('a', 1, ['group1']);
+    cache.set('b', 2, ['group1', 'group2']);
+
+    cache.invalidateTags(['group1']);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+  });
+});

--- a/tests/utils/fetchWithRetry.test.ts
+++ b/tests/utils/fetchWithRetry.test.ts
@@ -1,0 +1,16 @@
+import fetchWithRetry from '../../src/utils/fetchWithRetry';
+
+declare const global: any;
+
+describe('fetchWithRetry', () => {
+  it('retries on failure', async () => {
+    const fetchMock = jest.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock;
+
+    const res = await fetchWithRetry('http://example.com', { retries: 1, retryDelay: 1 });
+    expect(res.ok).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `fetchWithRetry` helper with timeout, abort signal and jittered retries
- introduce in-memory tag cache for group invalidation
- standardize route errors and handler middleware

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd9ddfa48328bc832e3d524dd5f9