### PR TITLE
feat: add app shell and route groups

### DIFF
--- a/src/app/(apps)/admin/AdminApp.tsx
+++ b/src/app/(apps)/admin/AdminApp.tsx
@@ -1,0 +1,6 @@
+'use client';
+import React from 'react';
+
+export default function AdminApp() {
+  return <div>Admin application</div>;
+}

--- a/src/app/(apps)/admin/page.tsx
+++ b/src/app/(apps)/admin/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { capabilities } from '../../lib/capabilities';
+import { guarded } from '../../lib/guard';
+
+export const revalidate = 0;
+
+export default async function AdminPage() {
+  const AdminApp = await guarded(
+    capabilities.admin,
+    () => import('./AdminApp'),
+  );
+
+  if (!AdminApp) {
+    return <p>Access denied</p>;
+  }
+
+  return <AdminApp />;
+}

--- a/src/app/(apps)/layout.tsx
+++ b/src/app/(apps)/layout.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 0;
+
+export default function AppsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(apps)/page.tsx
+++ b/src/app/(apps)/page.tsx
@@ -1,0 +1,3 @@
+export default function AppsHome() {
+  return <p>Apps home</p>;
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function PublicLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,3 @@
+export default function PublicHome() {
+  return <p>Public home</p>;
+}

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 0;
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(settings)/page.tsx
+++ b/src/app/(settings)/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsHome() {
+  return <p>Settings home</p>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import React, { Suspense } from 'react';
+import Header from '../components/Header';
+import Nav from '../components/Nav';
+import WindowManager from '../components/WindowManager';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Header />
+        <Nav />
+        <WindowManager />
+        <Suspense fallback={<div>Loading...</div>}>
+          {children}
+        </Suspense>
+      </body>
+    </html>
+  );
+}

--- a/src/app/lib/capabilities.ts
+++ b/src/app/lib/capabilities.ts
@@ -1,0 +1,7 @@
+export interface Capabilities {
+  admin: boolean;
+}
+
+export const capabilities: Capabilities = {
+  admin: false,
+};

--- a/src/app/lib/guard.ts
+++ b/src/app/lib/guard.ts
@@ -1,0 +1,10 @@
+export async function guarded<T>(
+  allowed: boolean,
+  loader: () => Promise<{ default: T }>,
+): Promise<T | null> {
+  if (!allowed) {
+    return null;
+  }
+  const mod = await loader();
+  return mod.default;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,10 @@
+'use client';
+import React from 'react';
+
+export default function Header() {
+  return (
+    <header>
+      <h1>GPortfolio</h1>
+    </header>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,0 +1,10 @@
+'use client';
+import React from 'react';
+
+export default function Nav() {
+  return (
+    <nav>
+      <a href="/">Home</a>
+    </nav>
+  );
+}

--- a/src/components/WindowManager.tsx
+++ b/src/components/WindowManager.tsx
@@ -1,0 +1,8 @@
+'use client';
+import React from 'react';
+
+export default function WindowManager() {
+  return (
+    <div id="window-manager" />
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "strict": true,
+    "jsx": "react",
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- scaffold top-level layout rendering header, nav, and window manager with Suspense for main content
- organize routes into public, apps, and settings groups with segment revalidation
- add capability-based guard to avoid importing heavy client code unless authorized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4bd6c108328836b2a54e27326bd