### PR TITLE
Add locale and A/B testing middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+
+const LOCALE_COOKIE = 'locale';
+const AB_COOKIE = 'ab-test';
+const TRACKING_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  'gclid',
+  'fbclid',
+  'ref',
+];
+
+function getCookie(req: Request, name: string): string | undefined {
+  const cookie = req.headers.get('cookie');
+  if (!cookie) return undefined;
+  const match = cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match?.[1];
+}
+
+export function middleware(request: Request) {
+  const url = new URL(request.url);
+  let modified = false;
+
+  TRACKING_PARAMS.forEach((param) => {
+    if (url.searchParams.has(param)) {
+      url.searchParams.delete(param);
+      modified = true;
+    }
+  });
+
+  const response = modified ? NextResponse.redirect(url) : NextResponse.next();
+
+  const country = ((request as any).geo?.country as string) || 'US';
+  const acceptLang = request.headers.get('accept-language') || 'en';
+  const lang = acceptLang.split(',')[0].split('-')[0];
+  const locale = `${lang}-${country}`.toLowerCase();
+  const currentLocale = getCookie(request, LOCALE_COOKIE);
+
+  if (currentLocale !== locale) {
+    response.cookies.set(LOCALE_COOKIE, locale, { maxAge: 60 * 60 * 24, path: '/' });
+  }
+
+  if (!getCookie(request, AB_COOKIE)) {
+    const variant = Math.random() < 0.5 ? 'A' : 'B';
+    response.cookies.set(AB_COOKIE, variant, { maxAge: 60 * 60, path: '/' });
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/src/next-env.d.ts
+++ b/src/next-env.d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+declare module 'next/server' {
+  export class NextResponse extends Response {
+    static next(init?: { headers?: HeadersInit }): NextResponse;
+    static redirect(url: URL, status?: number): NextResponse;
+    cookies: {
+      get(name: string): { value: string } | undefined;
+      set(name: string, value: string, options?: { maxAge?: number; path?: string }): void;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add middleware that cleans tracking parameters and redirects to canonical URLs
- derive locale from geo and language headers and store in cookie
- assign users to short-lived A/B testing variants via cookie

## Testing
- `npx eslint --ext .js,.ts .`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b3e4be635c8328bca16ca07b34460f