### PR TITLE
feat: add versioned form autosave with merge UI

### DIFF
--- a/src/modules/server/FormStore.ts
+++ b/src/modules/server/FormStore.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express';
+
+export interface Diff {
+  [key: string]: { current: any; incoming: any };
+}
+
+export function calculateDiff(current: any, incoming: any): Diff {
+  const diff: Diff = {};
+  const keys = new Set([...Object.keys(current || {}), ...Object.keys(incoming || {})]);
+  keys.forEach((key) => {
+    const cur = current ? current[key] : undefined;
+    const inc = incoming ? incoming[key] : undefined;
+    if (JSON.stringify(cur) !== JSON.stringify(inc)) {
+      diff[key] = { current: cur, incoming: inc };
+    }
+  });
+  return diff;
+}
+
+export default class FormStore {
+  private data: any = {};
+
+  private version = 0;
+
+  submit(req: Request, res: Response): void {
+    const incomingVersion = req.headers['if-match']
+      ? Number(req.headers['if-match'])
+      : Number((req.body && req.body.version) || 0);
+    const incomingData = req.body && req.body.data ? req.body.data : {};
+
+    if (incomingVersion !== this.version) {
+      res.status(409).json({
+        message: 'Version conflict',
+        version: this.version,
+        diff: calculateDiff(this.data, incomingData),
+        current: this.data,
+      });
+      return;
+    }
+
+    this.version += 1;
+    this.data = incomingData;
+    res.json({ version: this.version });
+  }
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,16 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import express, { Application, Request, Response } from 'express';
+import FormStore from './FormStore';
 
 export default class Server {
+  private store = new FormStore();
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.use(express.json());
+    app.post('/api/form', (req: Request, res: Response) => {
+      this.store.submit(req, res);
+    });
   }
 }

--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -55,35 +55,39 @@
 <!--        </div>-->
 <!--    </div>-->
 <!--</section>-->
-<section>
-    <div class="section--name">
-        Global
-    </div>
-    <div class="section--items">
-        <div class="block">
-            <div class="block--label">
-                Template
+<form id="configForm">
+    <section>
+        <div class="section--name">
+            Global
+        </div>
+        <div class="section--items">
+            <div class="block">
+                <div class="block--label">
+                    Template
+                </div>
+                <div class="block--input">
+                    <input name="template"/>
+                </div>
+                <div class="block--description">
+                    Select an existing template
+                </div>
             </div>
-            <div class="block--input">
-                <input/>
-            </div>
-            <div class="block--description">
-                Select an existing template
+            <div class="block">
+                <div class="block--label">
+                    Base
+                </div>
+                <div class="block--input">
+                    <input name="base"/>
+                </div>
+                <div class="block--description">
+                    If the repository is called: &lt;username&gt;.github.io. Then the value is empty
+                    If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;
+                </div>
             </div>
         </div>
-        <div class="block">
-            <div class="block--label">
-                Base
-            </div>
-            <div class="block--input">
-                <input/>
-            </div>
-            <div class="block--description">
-                If the repository is called: &lt;username&gt;.github.io. Then the value is empty
-                If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;
-            </div>
-        </div>
-    </div>
-</section>
+    </section>
+    <div id="merge"></div>
+    <button type="submit">Save</button>
+</form>
 </body>
 </html>

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,75 @@
-(() => {
-  console.log('dev');
-})();
+let version = 0;
+const form = document.getElementById('configForm') as HTMLFormElement;
+const mergeDiv = document.getElementById('merge') as HTMLElement;
+
+function getFormData() {
+  const template = (form.elements.namedItem('template') as HTMLInputElement).value;
+  const base = (form.elements.namedItem('base') as HTMLInputElement).value;
+  return { template, base };
+}
+
+async function autosave() {
+  const data = getFormData();
+  const response = await fetch('/api/form', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data, version }),
+  });
+  if (response.ok) {
+    const json = await response.json();
+    version = json.version;
+  }
+}
+
+function showMerge(diff: any, serverVersion: number, serverData: any) {
+  mergeDiv.innerHTML = '';
+  Object.keys(diff).forEach((key) => {
+    const wrapper = document.createElement('div');
+    const message = document.createElement('div');
+    message.innerHTML = `<strong>${key}</strong>: server="${diff[key].current ?? ''}" local="${diff[key].incoming ?? ''}"`;
+    const accept = document.createElement('button');
+    accept.textContent = 'Accept Server';
+    accept.onclick = () => {
+      const input = form.elements.namedItem(key) as HTMLInputElement;
+      if (input) input.value = serverData[key] ?? '';
+      version = serverVersion;
+      mergeDiv.innerHTML = '';
+    };
+    const overwrite = document.createElement('button');
+    overwrite.textContent = 'Overwrite';
+    overwrite.onclick = () => {
+      version = serverVersion;
+      autosave();
+      mergeDiv.innerHTML = '';
+    };
+    wrapper.appendChild(message);
+    wrapper.appendChild(accept);
+    wrapper.appendChild(overwrite);
+    mergeDiv.appendChild(wrapper);
+  });
+}
+
+form.addEventListener('input', () => {
+  autosave();
+});
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = getFormData();
+  const response = await fetch('/api/form', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'If-Match': String(version),
+    },
+    body: JSON.stringify({ data }),
+  });
+
+  if (response.status === 409) {
+    const json = await response.json();
+    showMerge(json.diff, json.version, json.current);
+  } else if (response.ok) {
+    const json = await response.json();
+    version = json.version;
+  }
+});

--- a/tests/modules/server/FormStore.test.ts
+++ b/tests/modules/server/FormStore.test.ts
@@ -1,0 +1,41 @@
+import FormStore from '../../../src/modules/server/FormStore';
+
+describe('FormStore', () => {
+  function createRes() {
+    const res: any = {};
+    res.statusCode = 200;
+    res.status = (code: number) => {
+      res.statusCode = code;
+      return res;
+    };
+    res.jsonData = undefined;
+    res.json = (data: any) => {
+      res.jsonData = data;
+      return res;
+    };
+    return res;
+  }
+
+  it('increments version on successful submit', () => {
+    const store = new FormStore();
+    const req: any = { headers: {}, body: { data: { foo: 'a' }, version: 0 } };
+    const res = createRes();
+    store.submit(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonData.version).toBe(1);
+  });
+
+  it('returns diff on version conflict', () => {
+    const store = new FormStore();
+    const firstReq: any = { headers: {}, body: { data: { foo: 'a' }, version: 0 } };
+    const firstRes = createRes();
+    store.submit(firstReq, firstRes);
+
+    const conflictReq: any = { headers: { 'if-match': '0' }, body: { data: { foo: 'b' } } };
+    const conflictRes = createRes();
+    store.submit(conflictReq, conflictRes);
+
+    expect(conflictRes.statusCode).toBe(409);
+    expect(conflictRes.jsonData.diff.foo).toEqual({ current: 'a', incoming: 'b' });
+  });
+});


### PR DESCRIPTION
## Summary
- add FormStore with server-side version conflict handling
- autosave form with monotonically increasing version and merge conflict UI
- test FormStore versioning and diff logic

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e4bf3b00832888cfdd338bc95aff