### PR TITLE
feat: add HTML sanitization and link security

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "ts-loader": "^9.1.2",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2",
+    "sanitize-html": "^2.11.0",
+    "@types/sanitize-html": "^2.9.5",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.11.2",

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -111,6 +111,7 @@ export default class Application implements IApplication {
         path: '',
         protocol: 'https',
       },
+      blocklist: [],
     };
   }
 

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -23,6 +23,7 @@ export interface IConfigGlobal {
   pwa: ManifestOptions | null
   meta: object
   www: IConfigGlobalWww
+  blocklist: string[]
 }
 
 export interface IConfigGlobalWww {

--- a/src/templates/_common/scripts/template.ts
+++ b/src/templates/_common/scripts/template.ts
@@ -15,3 +15,5 @@ export function resolveFile(url: string | Function): string {
 
   return url().default;
 }
+
+export { default as sanitize, validateUrl } from '../../utils/sanitize';

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -3,7 +3,7 @@
 <%
 const { di } = require('../../di');
 const { TYPES } = require('../../types');
-const { safeQuotes, resolveFile } = require('../_common/scripts/template');
+const { safeQuotes, resolveFile, validateUrl } = require('../_common/scripts/template');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
@@ -19,7 +19,7 @@ function generateRepositoriesHtml(repositories) {
 
   for (var i = 0; i < repositories.length; i++) {
     output +=
-      `<a href="${repositories[i].html_url}" class="repository" target="_blank">
+      `<a href="${validateUrl(repositories[i].html_url, config.global.blocklist) || '#'}" class="repository" target="_blank" rel="noopener noreferrer">
         <div class="repository__name">${repositories[i].full_name}</div>
         <div class="repository__description">
           <p>${repositories[i].description || '-'}</p>
@@ -69,7 +69,7 @@ function generateRepositoriesHtml(repositories) {
     <% if (config.data.links.length > 0) { %>
       <div class="header__wrap__social">
         <% for (const link of config.data.links) { %>
-          <a href="<%= link.url %>" title="<%= safeQuotes(link.name) %>" rel="nofollow">
+          <a href="<%= validateUrl(link.url, config.global.blocklist) || '#' %>" title="<%= safeQuotes(link.name) %>" rel="nofollow noopener noreferrer" target="_blank">
             <%= require(`!!svg-inline-loader!../_common/assets/icons/${link.name}.svg`) %>
           </a>
         <% } %>

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,71 @@
+import sanitizeHtml from 'sanitize-html';
+
+export interface SanitizeOptions {
+  allowedTags?: string[];
+  allowedAttributes?: { [key: string]: string[] };
+  blocklist?: string[];
+}
+
+export function validateUrl(url: string, blocklist: string[] = []): string | null {
+  if (!url) {
+    return null;
+  }
+
+  if (url.startsWith('#') || url.startsWith('/')) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+
+    if (blocklist.some((domain) => parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`))) {
+      return null;
+    }
+
+    return parsed.toString();
+  } catch (e) {
+    return null;
+  }
+}
+
+export default function sanitize(html: string, options: SanitizeOptions = {}): string {
+  const {
+    allowedTags = ['a', 'b', 'i', 'em', 'strong', 'p', 'ul', 'ol', 'li', 'code', 'pre', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'img', 'br'],
+    allowedAttributes = {
+      a: ['href', 'title', 'target', 'rel'],
+      img: ['src', 'alt', 'title', 'width', 'height'],
+      '*': ['class'],
+    },
+    blocklist = [],
+  } = options;
+
+  return sanitizeHtml(html, {
+    allowedTags,
+    allowedAttributes,
+    transformTags: {
+      a: (tagName, attribs) => {
+        const href = validateUrl(attribs.href, blocklist);
+        if (!href) {
+          return { tagName: 'span', attribs: {} };
+        }
+
+        const newAttribs: any = { href };
+        if (/^https?:\/\//i.test(href)) {
+          newAttribs.rel = 'noopener noreferrer';
+          newAttribs.target = '_blank';
+        }
+        if (attribs.title) {
+          newAttribs.title = attribs.title;
+        }
+        if (attribs.class) {
+          newAttribs.class = attribs.class;
+        }
+        return { tagName, attribs: newAttribs };
+      },
+    },
+  });
+}
+

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,0 +1,27 @@
+import sanitize, { validateUrl } from '../../src/utils/sanitize';
+
+describe('sanitize', () => {
+  it('removes disallowed tags', () => {
+    const input = '<p>Hello</p><script>alert(1)</script>';
+    const output = sanitize(input);
+    expect(output).toBe('<p>Hello</p>');
+  });
+
+  it('rewrites external links', () => {
+    const input = '<a href="https://example.com">Example</a>';
+    const output = sanitize(input);
+    expect(output).toBe('<a href="https://example.com/" rel="noopener noreferrer" target="_blank">Example</a>');
+  });
+
+  it('blocks disallowed domains', () => {
+    const input = '<a href="https://bad.com">Bad</a>';
+    const output = sanitize(input, { blocklist: ['bad.com'] });
+    expect(output).toBe('<span>Bad</span>');
+  });
+
+  it('validates url with blocklist', () => {
+    expect(validateUrl('https://ok.com', ['bad.com'])).toBe('https://ok.com/');
+    expect(validateUrl('https://bad.com', ['bad.com'])).toBeNull();
+    expect(validateUrl('javascript:alert(1)')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize HTML content with allowlist and URL validation
- ensure external links open safely with rel and target attributes
- add configurable domain blocklist for content checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e4bfe5088328b44593c2f1760f1d