### PR TITLE
feat: add app catalog with manifest and dock

### DIFF
--- a/apps/sample-app/manifest.json
+++ b/apps/sample-app/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Sample App",
+  "icon": "sample.png",
+  "category": "utilities",
+  "permissions": ["storage"]
+}

--- a/src/interfaces/AppManifest.ts
+++ b/src/interfaces/AppManifest.ts
@@ -1,0 +1,6 @@
+export default interface AppManifest {
+  name: string;
+  icon: string;
+  category: string;
+  permissions: string[];
+}

--- a/src/modules/apps/AppCatalog.ts
+++ b/src/modules/apps/AppCatalog.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import AppManifest from '../../interfaces/AppManifest';
+
+export default class AppCatalog {
+  static load(appsDir: string = path.join(process.cwd(), 'apps')): AppManifest[] {
+    if (!fs.existsSync(appsDir)) {
+      return [];
+    }
+    return fs.readdirSync(appsDir)
+      .map((app) => {
+        const manifestPath = path.join(appsDir, app, 'manifest.json');
+        if (!fs.existsSync(manifestPath)) {
+          throw new Error(`Missing manifest for app: ${app}`);
+        }
+        const data = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as AppManifest;
+        if (!data.name || !data.icon || !data.category || !Array.isArray(data.permissions)) {
+          throw new Error(`Invalid manifest for app: ${app}`);
+        }
+        return data;
+      });
+  }
+
+  static filter(apps: AppManifest[], query: string, category?: string): AppManifest[] {
+    return apps.filter((app) => {
+      const matchesQuery = app.name.toLowerCase().includes(query.toLowerCase());
+      const matchesCategory = category ? app.category === category : true;
+      return matchesQuery && matchesCategory;
+    });
+  }
+}

--- a/src/modules/apps/Dock.ts
+++ b/src/modules/apps/Dock.ts
@@ -1,0 +1,38 @@
+export default class Dock {
+  private readonly storageKey = 'installedApps';
+
+  private read(): string[] {
+    if (typeof localStorage === 'undefined') {
+      return [];
+    }
+    const raw = localStorage.getItem(this.storageKey);
+    return raw ? JSON.parse(raw) : [];
+  }
+
+  private write(apps: string[]): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(this.storageKey, JSON.stringify(apps));
+    }
+  }
+
+  getInstalled(): string[] {
+    return this.read();
+  }
+
+  install(app: string): void {
+    const apps = this.read();
+    if (!apps.includes(app)) {
+      apps.push(app);
+      this.write(apps);
+    }
+  }
+
+  uninstall(app: string): void {
+    const apps = this.read().filter((a) => a !== app);
+    this.write(apps);
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(`app:${app}`);
+      localStorage.removeItem(`shortcut:${app}`);
+    }
+  }
+}

--- a/src/templates/catalog/index.ejs
+++ b/src/templates/catalog/index.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>App Catalog</title>
+</head>
+<body>
+  <input id="search" placeholder="Search apps" />
+  <select id="category">
+    <option value="">All</option>
+  </select>
+  <ul id="apps"></ul>
+  <script src="./index.ts"></script>
+</body>
+</html>

--- a/src/templates/catalog/index.ts
+++ b/src/templates/catalog/index.ts
@@ -1,0 +1,48 @@
+import AppCatalog from '../../modules/apps/AppCatalog';
+import Dock from '../../modules/apps/Dock';
+
+const manifests = AppCatalog.load();
+const dock = new Dock();
+
+const searchInput = document.getElementById('search') as HTMLInputElement;
+const categorySelect = document.getElementById('category') as HTMLSelectElement;
+const list = document.getElementById('apps') as HTMLUListElement;
+
+const categories = Array.from(new Set(manifests.map((m) => m.category)));
+
+categories.forEach((cat) => {
+  const option = document.createElement('option');
+  option.value = cat;
+  option.textContent = cat;
+  categorySelect.appendChild(option);
+});
+
+function render(): void {
+  const filtered = AppCatalog.filter(
+    manifests,
+    searchInput.value,
+    categorySelect.value || undefined,
+  );
+  list.innerHTML = '';
+  filtered.forEach((app) => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    const installed = dock.getInstalled().includes(app.name);
+    btn.textContent = installed ? 'Uninstall' : 'Install';
+    btn.addEventListener('click', () => {
+      if (installed) {
+        dock.uninstall(app.name);
+      } else {
+        dock.install(app.name);
+      }
+      render();
+    });
+    li.textContent = `${app.name} `;
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+searchInput.addEventListener('input', render);
+categorySelect.addEventListener('change', render);
+render();

--- a/tests/modules/AppCatalog.test.ts
+++ b/tests/modules/AppCatalog.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import AppCatalog from '../../src/modules/apps/AppCatalog';
+
+describe('AppCatalog', () => {
+  it('loads manifests', () => {
+    const tmp = fs.mkdtempSync(path.join(process.cwd(), 'tmp-apps-'));
+    fs.mkdirSync(path.join(tmp, 'app1'));
+    fs.writeFileSync(path.join(tmp, 'app1', 'manifest.json'), JSON.stringify({
+      name: 'App1',
+      icon: 'icon.png',
+      category: 'test',
+      permissions: ['storage'],
+    }));
+    const manifests = AppCatalog.load(tmp);
+    expect(manifests).toHaveLength(1);
+    expect(manifests[0].name).toBe('App1');
+  });
+
+  it('throws if manifest missing', () => {
+    const tmp = fs.mkdtempSync(path.join(process.cwd(), 'tmp-apps-'));
+    fs.mkdirSync(path.join(tmp, 'app1'));
+    expect(() => AppCatalog.load(tmp)).toThrow('Missing manifest');
+  });
+});

--- a/tests/modules/Dock.test.ts
+++ b/tests/modules/Dock.test.ts
@@ -1,0 +1,34 @@
+import Dock from '../../src/modules/apps/Dock';
+
+describe('Dock', () => {
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+      getItem(key: string) {
+        return store[key] || null;
+      },
+      setItem(key: string, value: string) {
+        store[key] = value;
+      },
+      removeItem(key: string) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+    };
+  })();
+  (global as any).localStorage = localStorageMock;
+
+  it('installs and uninstalls apps', () => {
+    const dock = new Dock();
+    dock.install('Sample');
+    expect(dock.getInstalled()).toContain('Sample');
+    localStorage.setItem('app:Sample', 'state');
+    localStorage.setItem('shortcut:Sample', '1');
+    dock.uninstall('Sample');
+    expect(dock.getInstalled()).not.toContain('Sample');
+    expect(localStorage.getItem('app:Sample')).toBeNull();
+    expect(localStorage.getItem('shortcut:Sample')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- require app manifest with name, icon, category and permissions
- add catalog view with search/filter and install toggles
- implement dock uninstall removing app state and shortcuts

## Testing
- `yarn test`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c37ce88328b5af27a3c294f2c5