### PR TITLE
Add capability helper and redaction utilities

### DIFF
--- a/src/services/github/GithubDataAdapter.ts
+++ b/src/services/github/GithubDataAdapter.ts
@@ -1,11 +1,12 @@
 import IGithubProfile from './interfaces/IGithubProfile';
 import { IConfigDataLink, IConfigData } from '../../interfaces/IConfig';
+import redact from '../../utils/redact';
 
 export default class GithubDataAdapter implements IConfigData {
   private profile: IGithubProfile;
 
   constructor(profile: IGithubProfile) {
-    this.profile = profile;
+    this.profile = redact(profile, ['node_id', 'email']);
   }
 
   get login(): string {

--- a/src/services/github/GithubService.ts
+++ b/src/services/github/GithubService.ts
@@ -9,6 +9,7 @@ import { TYPES } from '../../types';
 import IApplication from '../../interfaces/IApplication';
 import IGithubProfile from './interfaces/IGithubProfile';
 import IGithubRepository from './interfaces/IGithubRepository';
+import redact from '../../utils/redact';
 
 @injectable()
 export default class GithubService implements IService {
@@ -37,9 +38,14 @@ export default class GithubService implements IService {
   }
 
   public configuration(): IGithub {
+    const profile = this.profileData
+      ? redact(this.profileData, ['node_id', 'email'])
+      : undefined;
+    const repositories = this.repositoriesData.map((repo) => redact(repo, ['node_id']));
+
     return {
       configuration: {
-        nickname: this.profileData ? this.profileData.login : '',
+        nickname: profile ? profile.login : '',
         fetcher: {
           repositories: {
             type: 'owner',
@@ -57,8 +63,8 @@ export default class GithubService implements IService {
         },
       },
       data: {
-        profile: this.profileData,
-        repositories: this.repositoriesData,
+        profile,
+        repositories,
       },
     };
   }

--- a/src/services/github/fetcher/GithubPrivateFetcher.ts
+++ b/src/services/github/fetcher/GithubPrivateFetcher.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import GithubRequest from '../GithubRequest';
 import IGithubFetcher from '../interfaces/IGithubFetcher';
 import IGithubConfigRepository from '../interfaces/IGithubConfigRepository';
+import redact from '../../../utils/redact';
 
 export default class GithubPrivateFetcher implements IGithubFetcher {
   protected token: string;
@@ -37,5 +38,9 @@ export default class GithubPrivateFetcher implements IGithubFetcher {
         per_page: perPage,
       },
     });
+  }
+
+  public toJSON(): Record<string, unknown> {
+    return redact({ ...this }, ['token']);
   }
 }

--- a/src/utils/can.ts
+++ b/src/utils/can.ts
@@ -1,0 +1,37 @@
+export interface CapabilityDefinition {
+  endpoint: string;
+  element: string;
+  fallbackElement?: string;
+}
+
+export const CAPABILITY_MAP: Record<string, CapabilityDefinition> = {
+  EDIT_PROFILE: {
+    endpoint: '/api/profile',
+    element: 'button[data-action="edit-profile"]',
+    fallbackElement: 'span[data-action="edit-profile"]',
+  },
+  DELETE_REPOSITORY: {
+    endpoint: '/api/repos/:id',
+    element: 'button[data-action="delete-repo"]',
+    fallbackElement: 'span[data-action="delete-repo"]',
+  },
+};
+
+export interface CanResult {
+  allowed: boolean;
+  element: string;
+  endpoint?: string;
+}
+
+export default function can(
+  userCapabilities: string[],
+  flag: keyof typeof CAPABILITY_MAP,
+): CanResult {
+  const definition = CAPABILITY_MAP[flag];
+  const allowed = userCapabilities.includes(flag);
+  return {
+    allowed,
+    element: allowed ? definition.element : definition.fallbackElement || definition.element,
+    endpoint: allowed ? definition.endpoint : undefined,
+  };
+}

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,9 @@
+export default function redact<T extends Record<string, any>>(data: T, fields: (keyof T)[]): T {
+  const clone: any = { ...data };
+  fields.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(clone, field)) {
+      clone[field] = undefined;
+    }
+  });
+  return clone as T;
+}

--- a/tests/utils/can.test.ts
+++ b/tests/utils/can.test.ts
@@ -1,0 +1,17 @@
+import can, { CAPABILITY_MAP } from '../../src/utils/can';
+
+describe('can helper', () => {
+  it('allows capability and exposes endpoint and element', () => {
+    const result = can(['EDIT_PROFILE'], 'EDIT_PROFILE');
+    expect(result.allowed).toBeTruthy();
+    expect(result.endpoint).toBe(CAPABILITY_MAP.EDIT_PROFILE.endpoint);
+    expect(result.element).toBe(CAPABILITY_MAP.EDIT_PROFILE.element);
+  });
+
+  it('falls back when capability missing', () => {
+    const result = can([], 'EDIT_PROFILE');
+    expect(result.allowed).toBeFalsy();
+    expect(result.endpoint).toBeUndefined();
+    expect(result.element).toBe(CAPABILITY_MAP.EDIT_PROFILE.fallbackElement);
+  });
+});

--- a/tests/utils/redact.test.ts
+++ b/tests/utils/redact.test.ts
@@ -1,0 +1,10 @@
+import redact from '../../src/utils/redact';
+
+describe('redact', () => {
+  it('removes sensitive fields', () => {
+    const data = { a: 1, secret: 'shh' };
+    const cleaned = redact(data, ['secret']);
+    expect(cleaned).toStrictEqual({ a: 1, secret: undefined });
+    expect(data.secret).toBe('shh');
+  });
+});


### PR DESCRIPTION
## Summary
- add `can()` helper to map capabilities to UI selectors and API endpoints with read-only fallbacks
- introduce generic `redact()` utility and apply to GitHub service and models
- cover new helpers with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c534f4832891cb3f028a8f7ec3