### PR TITLE
feat: add request id tracking for API calls

### DIFF
--- a/src/modules/error/RequestError.ts
+++ b/src/modules/error/RequestError.ts
@@ -1,0 +1,45 @@
+export interface RequestErrorPayload {
+  requestId: string;
+  summary: unknown;
+}
+
+export function buildSupportBundle(payload: RequestErrorPayload): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+export function openRequestErrorModal(payload: RequestErrorPayload): void {
+  const content = buildSupportBundle(payload);
+  if (typeof document !== 'undefined') {
+    let modal = document.getElementById('request-error-modal');
+    if (!modal) {
+      modal = document.createElement('pre');
+      modal.id = 'request-error-modal';
+      modal.style.position = 'fixed';
+      modal.style.top = '10px';
+      modal.style.right = '10px';
+      modal.style.background = '#fff';
+      modal.style.border = '1px solid #000';
+      modal.style.padding = '10px';
+      modal.style.zIndex = '1000';
+      document.body.appendChild(modal);
+    }
+    modal.textContent = content;
+  } else {
+    console.info(content);
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    navigator.clipboard.writeText(content).catch(() => {});
+  }
+}
+
+export function showRequestErrorToast(payload: RequestErrorPayload): void {
+  const message = `Request failed. ID: ${payload.requestId}`;
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    window.alert(message);
+  } else {
+    console.error(message);
+  }
+
+  openRequestErrorModal(payload);
+}

--- a/src/services/github/GithubLoggerFetcher.ts
+++ b/src/services/github/GithubLoggerFetcher.ts
@@ -6,6 +6,8 @@ import IGithubFetcher from './interfaces/IGithubFetcher';
 import IGithubProfile from './interfaces/IGithubProfile';
 import { TYPES } from '../../types';
 import IPrefixLogger from '../../modules/logger/interfaces/IPrefixLogger';
+import generateRequestId from '../../utils/requestId';
+import { showRequestErrorToast } from '../../modules/error/RequestError';
 
 @injectable()
 export default class GithubLoggerFetcher extends GithubRequest {
@@ -22,31 +24,37 @@ export default class GithubLoggerFetcher extends GithubRequest {
     params: IGithubConfigRepository,
     page: number,
     perPage: number,
-  ): Promise<IGithubRepository[]> {
-    this.logger.info(`Starting fetch repositories: page = ${page}, perPage = ${perPage}`);
+  ): Promise<{ requestId: string; data: IGithubRepository[] }> {
+    const requestId = generateRequestId();
+    this.logger.info(`Starting fetch repositories [${requestId}]: page = ${page}, perPage = ${perPage}`);
 
-    return super.fetchRepositories(params, page, perPage)
-      .then((repositories) => {
-        this.logger.log(`Complete repositories, count = ${repositories.length}`);
-        return repositories;
+    return super.fetchRepositories(params, page, perPage, requestId)
+      .then((result) => {
+        this.logger.log(`Complete repositories [${requestId}], count = ${result.data.length}`);
+        return result;
       })
       .catch((err) => {
-        this.logger.error(err.response.data || err.message);
-        throw err;
+        const summary = err.response?.data || err.message;
+        showRequestErrorToast({ requestId, summary });
+        this.logger.error(`[${requestId}] ${summary}`);
+        throw { requestId, error: err };
       });
   }
 
-  public fetchProfile(): Promise<IGithubProfile> {
-    this.logger.info('Starting fetch profile');
+  public fetchProfile(): Promise<{ requestId: string; data: IGithubProfile }> {
+    const requestId = generateRequestId();
+    this.logger.info(`Starting fetch profile [${requestId}]`);
 
-    return super.fetchProfile()
-      .then((profile) => {
-        this.logger.log('Complete profile');
-        return profile;
+    return super.fetchProfile(requestId)
+      .then((result) => {
+        this.logger.log(`Complete profile [${requestId}]`);
+        return result;
       })
       .catch((err) => {
-        this.logger.error(err.response.data || err.message);
-        throw err;
+        const summary = err.response?.data || err.message;
+        showRequestErrorToast({ requestId, summary });
+        this.logger.error(`[${requestId}] ${summary}`);
+        throw { requestId, error: err };
       });
   }
 }

--- a/src/services/github/utils/profile.ts
+++ b/src/services/github/utils/profile.ts
@@ -19,12 +19,13 @@ if (fetcher === undefined) {
 const githubFetcher = new GithubLoggerFetcher(fetcher, logger);
 
 githubFetcher.fetchProfile()
-  .then((profile) => {
+  .then(({ data: profile }) => {
     fs.writeFileSync(
       path.resolve(__dirname, '../../../../data/github-profile.json'),
       JSON.stringify(profile, null, 2),
     );
   })
-  .catch(() => {
+  .catch(({ requestId, error }) => {
+    logger.error(`[${requestId}] ${error.response?.data || error.message}`);
     process.exit(1);
   });

--- a/src/services/github/utils/repositories.ts
+++ b/src/services/github/utils/repositories.ts
@@ -27,6 +27,7 @@ githubFetcher.fetchAllRepositories(github.configuration.fetcher.repositories)
       JSON.stringify(repositories, null, 2),
     );
   })
-  .catch(() => {
+  .catch(({ requestId, error }) => {
+    logger.error(`[${requestId}] ${error.response?.data || error.message}`);
     process.exit(1);
   });

--- a/src/utils/requestId.ts
+++ b/src/utils/requestId.ts
@@ -1,0 +1,4 @@
+export default function generateRequestId(): string {
+  const random = Math.random().toString(36).substring(2, 8);
+  return `${Date.now().toString(36)}-${random}`;
+}


### PR DESCRIPTION
## Summary
- generate request IDs for GitHub API calls and attach to responses
- surface errors through toast->modal with copyable support bundle
- update GitHub scripts to log request IDs and error details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c5b3a88328b1130a8f9370b3b5