### PR TITLE
feat: add user data import/export endpoints

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,63 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import express, { Application } from 'express';
+import UserDataExporter from '../userData/Exporter';
+import UserDataImporter from '../userData/Importer';
+
+const demoUser: Record<string, any> = {
+  login: 'demo',
+  first_name: 'Demo',
+  last_name: 'User',
+};
+
+const jobs: Record<string, { importer: UserDataImporter; progress: number; result?: any }> = {};
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.use(express.json());
+
+    app.get('/api/users/export', (req, resp) => {
+      const { format = 'json', version = 'v1' } = req.query as { format?: string; version?: string };
+      const exporter = new UserDataExporter();
+      const output = exporter.export(demoUser, (format as 'json' | 'csv'), version);
+      if (format === 'csv') {
+        resp.type('text/csv');
+      } else {
+        resp.type('application/json');
+      }
+      resp.send(output);
+    });
+
+    app.post('/api/users/import', (req, resp) => {
+      const importer = new UserDataImporter();
+      const { version, data } = req.body;
+      if (!importer.validate({ version, data }, 'v1')) {
+        resp.status(400).json({ error: 'Invalid schema version' });
+        return;
+      }
+      const preview = importer.preview(demoUser, data);
+      if (req.query.preview) {
+        resp.json({ preview });
+        return;
+      }
+      const jobId = Date.now().toString();
+      jobs[jobId] = { importer, progress: 0 };
+      importer.on('progress', (p) => { jobs[jobId].progress = p; });
+      importer.process(demoUser, data).then((result) => { jobs[jobId].result = result; });
+      resp.json({ jobId });
+    });
+
+    app.get('/api/users/import/:id/progress', (req, resp) => {
+      const job = jobs[req.params.id];
+      if (!job) {
+        resp.status(404).end();
+        return;
+      }
+      resp.json({ progress: job.progress, done: !!job.result, result: job.result || null });
+      if (job.result) {
+        delete jobs[req.params.id];
+      }
+    });
   }
 }

--- a/src/modules/userData/Exporter.ts
+++ b/src/modules/userData/Exporter.ts
@@ -1,0 +1,13 @@
+import { stringify as csvStringify } from './csv';
+
+export default class UserDataExporter {
+  export(data: Record<string, any>, format: 'json' | 'csv', version: string): string {
+    const payload = { version, data };
+    if (format === 'csv') {
+      const headers = ['schemaVersion', ...Object.keys(data)];
+      const row = [version, ...headers.slice(1).map((k) => data[k])];
+      return csvStringify([headers, row]);
+    }
+    return JSON.stringify(payload, null, 2);
+  }
+}

--- a/src/modules/userData/Importer.ts
+++ b/src/modules/userData/Importer.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'events';
+
+export interface ImportPreview {
+  added: Record<string, any>;
+  updated: Record<string, { from: any; to: any }>;
+}
+
+export default class UserDataImporter extends EventEmitter {
+  validate(input: { version: string; data: Record<string, any> }, expectedVersion: string): boolean {
+    return input.version === expectedVersion;
+  }
+
+  preview(existing: Record<string, any>, incoming: Record<string, any>): ImportPreview {
+    const added: Record<string, any> = {};
+    const updated: Record<string, { from: any; to: any }> = {};
+    Object.keys(incoming).forEach((key) => {
+      if (!(key in existing)) {
+        added[key] = incoming[key];
+      } else if (existing[key] !== incoming[key]) {
+        updated[key] = { from: existing[key], to: incoming[key] };
+      }
+    });
+    return { added, updated };
+  }
+
+  async process(existing: Record<string, any>, incoming: Record<string, any>): Promise<Record<string, any>> {
+    const keys = Object.keys(incoming);
+    const result = { ...existing };
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      result[key] = incoming[key];
+      this.emit('progress', Math.round(((i + 1) / keys.length) * 100));
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    return result;
+  }
+}

--- a/src/modules/userData/csv.ts
+++ b/src/modules/userData/csv.ts
@@ -1,0 +1,9 @@
+export function stringify(rows: any[][]): string {
+  return rows
+    .map((row) => row.map((value) => {
+      if (value === null || value === undefined) return '';
+      const str = String(value);
+      return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+    }).join(','))
+    .join('\n');
+}

--- a/tests/modules/UserDataImportExport.test.ts
+++ b/tests/modules/UserDataImportExport.test.ts
@@ -1,0 +1,39 @@
+import UserDataExporter from '../../src/modules/userData/Exporter';
+import UserDataImporter from '../../src/modules/userData/Importer';
+
+describe('User data import/export', () => {
+  const sample = { login: 'demo', first_name: 'Demo' };
+
+  it('exports JSON with version', () => {
+    const exporter = new UserDataExporter();
+    const output = exporter.export(sample, 'json', 'v1');
+    const parsed = JSON.parse(output);
+    expect(parsed.version).toBe('v1');
+    expect(parsed.data).toEqual(sample);
+  });
+
+  it('exports CSV with version', () => {
+    const exporter = new UserDataExporter();
+    const output = exporter.export(sample, 'csv', 'v1');
+    expect(output.split('\n')[0]).toBe('schemaVersion,login,first_name');
+    expect(output.split('\n')[1]).toBe('v1,demo,Demo');
+  });
+
+  it('validates and previews imports', () => {
+    const importer = new UserDataImporter();
+    const payload = { version: 'v1', data: { login: 'demo', first_name: 'New' } };
+    expect(importer.validate(payload, 'v1')).toBe(true);
+    const preview = importer.preview(sample, payload.data);
+    expect(preview.updated.first_name).toEqual({ from: 'Demo', to: 'New' });
+  });
+
+  it('emits progress during processing', async () => {
+    const importer = new UserDataImporter();
+    const payload = { login: 'demo', first_name: 'New', last_name: 'User' };
+    const progresses: number[] = [];
+    importer.on('progress', (p) => progresses.push(p));
+    const result = await importer.process({}, payload);
+    expect(result).toEqual(payload);
+    expect(progresses[progresses.length - 1]).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- add exporter and importer modules with schema-versioned JSON/CSV support
- expose API endpoints for exporting data and background imports with progress
- cover import/export flow with unit tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c6cd788328925163e41723efb0