### PR TITLE
feat: add privacy mode with auto activation

### DIFF
--- a/src/modules/core/PrivacyMode.ts
+++ b/src/modules/core/PrivacyMode.ts
@@ -1,0 +1,146 @@
+export interface PrivacyModeOptions {
+  /** ms until privacy mode activates after window blur; 0 disables auto-activation */
+  timeout?: number;
+  /** optional pin required to deactivate */
+  pin?: string;
+  /** key used with ctrlKey to toggle privacy mode */
+  toggleKey?: string;
+  /** selector for sensitive panels to blur */
+  sensitiveSelector?: string;
+  /** selector for elements whose text should be masked */
+  maskSelector?: string;
+  /** replacement string when masking */
+  maskWith?: string;
+}
+
+/**
+ * Handles toggling of privacy mode which blurs/masks sensitive content.
+ */
+export default class PrivacyMode {
+  private active = false;
+
+  private readonly options: Required<PrivacyModeOptions>;
+
+  private timer: number | null = null;
+
+  private readonly promptFn: (message: string) => string | null;
+
+  constructor(options: PrivacyModeOptions = {}, promptFn?: (msg: string) => string | null) {
+    this.options = {
+      timeout: options.timeout ?? 0,
+      pin: options.pin ?? '',
+      toggleKey: options.toggleKey ?? 'p',
+      sensitiveSelector: options.sensitiveSelector ?? '[data-sensitive]',
+      maskSelector: options.maskSelector ?? '[data-mask]',
+      maskWith: options.maskWith ?? '***',
+    };
+
+    this.promptFn = promptFn || ((msg) => (typeof window !== 'undefined' && window.prompt ? window.prompt(msg) : null));
+
+    this.handleKeydown = this.handleKeydown.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', this.handleKeydown);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('blur', this.handleBlur);
+      window.addEventListener('focus', this.handleFocus);
+    }
+  }
+
+  /** Destroy listeners */
+  public destroy(): void {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', this.handleKeydown);
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('blur', this.handleBlur);
+      window.removeEventListener('focus', this.handleFocus);
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** whether privacy mode is active */
+  public isActive(): boolean {
+    return this.active;
+  }
+
+  public enable(): void {
+    if (this.active) return;
+    this.active = true;
+    if (typeof document !== 'undefined') {
+      document.body.classList.add('privacy-mode');
+      this.maskElements();
+    }
+  }
+
+  public disable(): void {
+    if (!this.active) return;
+    if (this.options.pin) {
+      const result = this.promptFn('Enter PIN to exit privacy mode');
+      if (result !== this.options.pin) {
+        return;
+      }
+    }
+    this.active = false;
+    if (typeof document !== 'undefined') {
+      document.body.classList.remove('privacy-mode');
+      this.unmaskElements();
+    }
+  }
+
+  public toggle(): void {
+    if (this.active) {
+      this.disable();
+    } else {
+      this.enable();
+    }
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    if (e.key.toLowerCase() === this.options.toggleKey.toLowerCase() && e.ctrlKey) {
+      this.toggle();
+    }
+  }
+
+  private handleBlur(): void {
+    if (this.options.timeout <= 0 || this.active) return;
+    this.timer = window.setTimeout(() => {
+      this.enable();
+    }, this.options.timeout);
+  }
+
+  private handleFocus(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private maskElements(): void {
+    const nodes = document.querySelectorAll(this.options.maskSelector);
+    nodes.forEach((node) => {
+      const el = node as HTMLElement;
+      if (!el.dataset.originalText) {
+        el.dataset.originalText = el.textContent || '';
+      }
+      el.textContent = this.options.maskWith;
+    });
+  }
+
+  private unmaskElements(): void {
+    const nodes = document.querySelectorAll(this.options.maskSelector);
+    nodes.forEach((node) => {
+      const el = node as HTMLElement;
+      if (el.dataset.originalText !== undefined) {
+        el.textContent = el.dataset.originalText;
+      }
+    });
+  }
+}
+

--- a/src/pages/config/index.scss
+++ b/src/pages/config/index.scss
@@ -1,1 +1,10 @@
 @import "styles/global";
+
+body.privacy-mode [data-sensitive] {
+  filter: blur(5px);
+}
+
+body.privacy-mode [data-mask] {
+  color: transparent;
+  text-shadow: 0 0 5px #000;
+}

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,8 @@
+import PrivacyMode from '../../modules/core/PrivacyMode';
+
 (() => {
-  console.log('dev');
+  // initialise privacy mode with 5s timeout before auto-activation
+  const privacyMode = new PrivacyMode({ timeout: 5000 });
+  // expose for debugging
+  (window as any).privacyMode = privacyMode;
 })();

--- a/tests/modules/PrivacyMode.test.ts
+++ b/tests/modules/PrivacyMode.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import PrivacyMode from '../../src/modules/core/PrivacyMode';
+
+describe('PrivacyMode', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="panel" data-sensitive>Secret</div><span id="name" data-mask>John</span>';
+  });
+
+  it('masks personal data when enabled', () => {
+    const pm = new PrivacyMode();
+    pm.enable();
+    expect(pm.isActive()).toBe(true);
+    expect(document.getElementById('name')?.textContent).toBe('***');
+    pm.destroy();
+  });
+
+  it('requires pin to disable when configured', () => {
+    const pm = new PrivacyMode({ pin: '1234' }, () => '0000');
+    pm.enable();
+    pm.disable();
+    expect(pm.isActive()).toBe(true);
+    const pm2 = new PrivacyMode({ pin: '1234' }, () => '1234');
+    pm2.enable();
+    pm2.disable();
+    expect(pm2.isActive()).toBe(false);
+    pm.destroy();
+    pm2.destroy();
+  });
+
+  it('auto activates after blur timeout', () => {
+    jest.useFakeTimers();
+    const pm = new PrivacyMode({ timeout: 100 });
+    window.dispatchEvent(new Event('blur'));
+    jest.advanceTimersByTime(100);
+    expect(pm.isActive()).toBe(true);
+    pm.destroy();
+    jest.useRealTimers();
+  });
+
+  it('toggles with keyboard shortcut', () => {
+    const pm = new PrivacyMode();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', ctrlKey: true }));
+    expect(pm.isActive()).toBe(true);
+    pm.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add PrivacyMode module to blur sensitive panels and mask personal data
- activate privacy mode via keyboard or when page loses focus for a timeout
- support optional PIN prompt to exit privacy mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c73a308328b7bb95d6f42229d2