### PR TITLE
Add hover card utility and contextual cursors

### DIFF
--- a/src/templates/_common/scripts/hover-card.ts
+++ b/src/templates/_common/scripts/hover-card.ts
@@ -1,0 +1,40 @@
+const HOVER_DELAY = 80;
+
+export function initHoverCards(): void {
+  const triggers = document.querySelectorAll<HTMLElement>('[data-hover-card]');
+  triggers.forEach((trigger) => {
+    const selector = trigger.dataset.hoverCard;
+    if (!selector) {
+      return;
+    }
+
+    const card = document.querySelector<HTMLElement>(selector);
+    if (!card) {
+      return;
+    }
+
+    let timeoutId: number;
+
+    const show = () => {
+      timeoutId = window.setTimeout(() => {
+        const rect = trigger.getBoundingClientRect();
+        card.style.left = `${rect.left + window.scrollX}px`;
+        card.style.top = `${rect.bottom + window.scrollY}px`;
+        card.classList.add('hover-card--visible');
+      }, HOVER_DELAY);
+    };
+
+    const hide = () => {
+      clearTimeout(timeoutId);
+      card.classList.remove('hover-card--visible');
+    };
+
+    trigger.addEventListener('mouseenter', show);
+    trigger.addEventListener('mouseleave', hide);
+
+    // Touch support for mobile devices
+    trigger.addEventListener('touchstart', show, { passive: true });
+    trigger.addEventListener('touchend', hide);
+    trigger.addEventListener('touchcancel', hide);
+  });
+}

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,3 +1,5 @@
+import { initHoverCards } from './hover-card';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
@@ -5,3 +7,5 @@
     });
   }
 })();
+
+initHoverCards();

--- a/src/templates/default/styles/helper.scss
+++ b/src/templates/default/styles/helper.scss
@@ -77,3 +77,38 @@
     border-color: #b2b2b2;
   }
 }
+
+// Cursor utility classes
+.cursor-drag {
+  cursor: grab;
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.cursor-resize {
+  cursor: nwse-resize;
+}
+
+.cursor-copy {
+  cursor: copy;
+}
+
+.cursor-blocked {
+  cursor: not-allowed;
+}
+
+// Hover card styles
+.hover-card {
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 80ms ease;
+  will-change: opacity;
+
+  &--visible {
+    opacity: 1;
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
## Summary
- provide utility classes for drag, resize, copy, and blocked cursors
- add hover card styles and initialization with 80ms reveal
- enable touch-based triggers for hover cards on mobile devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4cbb8ec832894cc83daaaab2df7