### PR TITLE
Add demo mode with example data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ $ yarn github:profile ACCESS_TOKEN
 $ yarn github:repositories ACCESS_TOKEN
 ```
 
+## Demo mode
+
+Run the project with example data and without any network calls:
+
+```shell
+$ yarn demo           # start dev server with demo content
+$ yarn demo:exit      # remove demo data and return to normal mode
+```
+
 ## How to contribute
 
 Please make sure to read the [Contributing Guide](https://github.com/GPortfolio/GPortfolio/blob/main/.github/CONTRIBUTING.md) before making a pull request.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
+    "demo:init": "ts-node ./src/demo/init.ts",
+    "demo:exit": "ts-node ./src/demo/exit.ts",
+    "demo": "DEMO_MODE=true yarn demo:init && DEMO_MODE=true yarn dev",
     "test": "jest"
   },
   "browserslist": [

--- a/src/demo/DemoDataGenerator.ts
+++ b/src/demo/DemoDataGenerator.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+
+export default class DemoDataGenerator {
+  private dataDir: string;
+
+  constructor(dataDir: string = path.resolve(__dirname, '../../data')) {
+    this.dataDir = dataDir;
+  }
+
+  public seed(): void {
+    if (!fs.existsSync(this.dataDir)) {
+      fs.mkdirSync(this.dataDir, { recursive: true });
+    }
+
+    const profilePath = path.join(this.dataDir, 'github-profile.json');
+    if (!fs.existsSync(profilePath)) {
+      const profile = {
+        login: 'demo',
+        name: 'Demo User',
+        avatar_url: 'https://avatars.githubusercontent.com/u/0?v=4',
+        bio: 'This is a demo profile',
+        html_url: 'https://github.com/demo',
+      };
+      fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+    }
+
+    const repositoriesPath = path.join(this.dataDir, 'github-repositories.json');
+    if (!fs.existsSync(repositoriesPath)) {
+      const repositories = [
+        {
+          id: 0,
+          name: 'demo-repo',
+          full_name: 'demo/demo-repo',
+          html_url: 'https://github.com/demo/demo-repo',
+          description: 'Example repository for demo mode',
+          fork: false,
+          stargazers_count: 0,
+          watchers_count: 0,
+          language: 'TypeScript',
+          forks_count: 0,
+          open_issues_count: 0,
+          default_branch: 'main',
+          created_at: '2021-01-01T00:00:00Z',
+          updated_at: '2021-01-01T00:00:00Z',
+          pushed_at: '2021-01-01T00:00:00Z',
+          owner: {
+            login: 'demo',
+          },
+        },
+      ];
+      fs.writeFileSync(repositoriesPath, JSON.stringify(repositories, null, 2));
+    }
+  }
+
+  public wipe(): void {
+    ['github-profile.json', 'github-repositories.json'].forEach((file) => {
+      const filePath = path.join(this.dataDir, file);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    });
+  }
+}

--- a/src/demo/exit.ts
+++ b/src/demo/exit.ts
@@ -1,0 +1,4 @@
+import DemoDataGenerator from './DemoDataGenerator';
+
+const generator = new DemoDataGenerator();
+generator.wipe();

--- a/src/demo/init.ts
+++ b/src/demo/init.ts
@@ -1,0 +1,4 @@
+import DemoDataGenerator from './DemoDataGenerator';
+
+const generator = new DemoDataGenerator();
+generator.seed();

--- a/src/services/github/fetcher/GithubDemoFetcher.ts
+++ b/src/services/github/fetcher/GithubDemoFetcher.ts
@@ -1,0 +1,44 @@
+import { AxiosResponse } from 'axios';
+import fs from 'fs';
+import path from 'path';
+import IGithubFetcher from '../interfaces/IGithubFetcher';
+import IGithubConfigRepository from '../interfaces/IGithubConfigRepository';
+
+export default class GithubDemoFetcher implements IGithubFetcher {
+  private dataDir: string;
+
+  constructor(dataDir: string = path.resolve(__dirname, '../../../../data')) {
+    this.dataDir = dataDir;
+  }
+
+  async fetchProfile(): Promise<AxiosResponse> {
+    const profilePath = path.join(this.dataDir, 'github-profile.json');
+    const data = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+    return {
+      data,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+  }
+
+  async fetchRepositories(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    params: IGithubConfigRepository,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    page: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    perPage: number,
+  ): Promise<AxiosResponse> {
+    const repositoriesPath = path.join(this.dataDir, 'github-repositories.json');
+    const data = JSON.parse(fs.readFileSync(repositoriesPath, 'utf-8'));
+    return {
+      data,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    };
+  }
+}

--- a/src/services/github/helper/utils.ts
+++ b/src/services/github/helper/utils.ts
@@ -4,10 +4,15 @@ import { di } from '../../../di';
 import IApplication from '../../../interfaces/IApplication';
 import { TYPES } from '../../../types';
 import GithubPublicFetcher from '../fetcher/GithubPublicFetcher';
+import GithubDemoFetcher from '../fetcher/GithubDemoFetcher';
 
 // eslint-disable-next-line import/prefer-default-export
 export function parseGithubFetcher(): IGithubFetcher | undefined {
   const args = process.argv.slice(2);
+
+  if (process.env.DEMO_MODE === 'true') {
+    return new GithubDemoFetcher();
+  }
 
   if (args.length && args[0]) {
     return new GithubPrivateFetcher(args[0]);

--- a/tests/demo/DemoDataGenerator.test.ts
+++ b/tests/demo/DemoDataGenerator.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import DemoDataGenerator from '../../src/demo/DemoDataGenerator';
+
+describe('DemoDataGenerator', () => {
+  it('seeds and wipes demo data', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-test-'));
+    const generator = new DemoDataGenerator(tmpDir);
+
+    generator.seed();
+    const profile = path.join(tmpDir, 'github-profile.json');
+    const repos = path.join(tmpDir, 'github-repositories.json');
+
+    expect(fs.existsSync(profile)).toBe(true);
+    expect(fs.existsSync(repos)).toBe(true);
+
+    generator.wipe();
+    expect(fs.existsSync(profile)).toBe(false);
+    expect(fs.existsSync(repos)).toBe(false);
+  });
+});

--- a/tests/services/parseGithubFetcher.test.ts
+++ b/tests/services/parseGithubFetcher.test.ts
@@ -1,0 +1,11 @@
+import GithubDemoFetcher from '../../src/services/github/fetcher/GithubDemoFetcher';
+import { parseGithubFetcher } from '../../src/services/github/helper/utils';
+
+describe('parseGithubFetcher demo mode', () => {
+  it('returns demo fetcher when DEMO_MODE is set', () => {
+    process.env.DEMO_MODE = 'true';
+    const fetcher = parseGithubFetcher();
+    expect(fetcher).toBeInstanceOf(GithubDemoFetcher);
+    delete process.env.DEMO_MODE;
+  });
+});


### PR DESCRIPTION
## Summary
- seed demo profile and repo data for first-time users
- add demo mode using stub GitHub fetcher and scripts to enter/exit demo
- document demo usage

## Testing
- `yarn lint && echo 'Lint success'`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4ce3f00832886469e5d25bfe1ce