### PR TITLE
Add middleware and ETag polling for feature flags

### DIFF
--- a/config/flags.preview.json
+++ b/config/flags.preview.json
@@ -1,0 +1,3 @@
+{
+  "exampleFlag": false
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,45 @@
+// Fetch read-only feature flags from Edge Config and expose via headers.
+
+// eslint-disable-next-line import/no-unresolved
+import { get } from '@vercel/edge-config';
+// eslint-disable-next-line import/no-unresolved
+import { NextRequest, NextResponse } from 'next/server';
+
+interface Flags {
+  [key: string]: unknown;
+}
+
+let previewFlags: Flags = {};
+try {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  previewFlags = require('./config/flags.preview.json');
+} catch {
+  // ignore missing preview config
+}
+
+async function loadFlags(): Promise<Flags> {
+  if (process.env.VERCEL_ENV === 'preview') {
+    return previewFlags;
+  }
+
+  try {
+    const flags = await get<Flags>('flags');
+    return flags || {};
+  } catch {
+    return {};
+  }
+}
+
+export async function middleware(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _req: NextRequest,
+) {
+  const flags = await loadFlags();
+  const res = NextResponse.next();
+  res.headers.set('x-feature-flags', JSON.stringify(flags));
+  return res;
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,0 +1,54 @@
+export type FeatureFlags = { [key: string]: any };
+
+export type FeatureFlagListener = (flags: FeatureFlags) => void;
+
+interface FeatureFlagClient {
+  subscribe(listener: FeatureFlagListener): () => void;
+  getFlags(): FeatureFlags;
+}
+
+export function createFeatureFlagClient(
+  url = '/api/feature-flags',
+  interval = 60000,
+): FeatureFlagClient {
+  let etag: string | null = null;
+  let flags: FeatureFlags = {};
+  const listeners: FeatureFlagListener[] = [];
+
+  async function poll(): Promise<void> {
+    try {
+      const headers: { [key: string]: string } = {};
+      if (etag) {
+        headers['If-None-Match'] = etag;
+      }
+
+      const response = await fetch(url, { headers });
+      if (response.status === 200) {
+        etag = response.headers.get('ETag');
+        flags = await response.json();
+        listeners.forEach((l) => l(flags));
+      }
+    } catch {
+      // ignore network errors
+    }
+  }
+
+  setInterval(poll, interval);
+  poll();
+
+  return {
+    subscribe(listener: FeatureFlagListener): () => void {
+      listeners.push(listener);
+      listener(flags);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) {
+          listeners.splice(index, 1);
+        }
+      };
+    },
+    getFlags(): FeatureFlags {
+      return flags;
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   "include": [
     "src",
     "tests",
+    "middleware.ts",
   ],
 }


### PR DESCRIPTION
## Summary
- expose Edge Config flags via `middleware.ts`
- add preview flag configuration for branch-specific builds
- introduce ETag-based feature flag polling client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e7f8ffb083289e17f611918f59ad