### PR TITLE
feat: add cache and rate limiter metrics endpoint

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,63 @@
+// Simple token bucket rate limiter backed by in-memory KV store
+
+interface Bucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+const CAPACITY = 60; // requests
+const INTERVAL = 60_000; // 1 minute in ms
+
+function getKey(req: any): string {
+  const ip = (req.headers?.['x-forwarded-for'] || req.connection?.remoteAddress || req.socket?.remoteAddress || '') as string;
+  const session = (req.headers?.['x-session-id'] || '') as string;
+  return `${ip}:${session}`;
+}
+
+export function rateLimit(req: any, res: any, limit = CAPACITY, interval = INTERVAL): boolean {
+  const key = getKey(req);
+  const now = Date.now();
+  let bucket = buckets.get(key);
+
+  if (!bucket) {
+    bucket = { tokens: limit, lastRefill: now };
+  } else {
+    const elapsed = now - bucket.lastRefill;
+    if (elapsed > 0) {
+      const refill = Math.floor(elapsed / interval);
+      if (refill > 0) {
+        bucket.tokens = Math.min(limit, bucket.tokens + refill * limit);
+        bucket.lastRefill += refill * interval;
+      }
+    }
+  }
+
+  if (bucket.tokens <= 0) {
+    const retryAfter = Math.ceil((bucket.lastRefill + interval - now) / 1000);
+    if (res.setHeader) {
+      res.setHeader('Retry-After', String(retryAfter));
+    }
+    if (typeof res.status === 'function') {
+      res.status(429).send?.('Too Many Requests');
+    } else {
+      res.statusCode = 429;
+      res.end?.('Too Many Requests');
+    }
+    buckets.set(key, bucket);
+    return false;
+  }
+
+  bucket.tokens -= 1;
+  buckets.set(key, bucket);
+  return true;
+}
+
+export function limiterStatus() {
+  return {
+    buckets: Array.from(buckets.entries()).map(([key, value]) => ({ key, tokens: value.tokens, lastRefill: value.lastRefill })),
+  };
+}
+
+export default rateLimit;

--- a/src/pages/api/admin/cache-metrics.ts
+++ b/src/pages/api/admin/cache-metrics.ts
@@ -1,0 +1,27 @@
+import { stats as cacheStats } from '../../../utils/kvCache';
+import { limiterStatus } from '../../../middleware/rateLimit';
+
+export default function handler(req: any, res: any): void {
+  if (req.headers?.['x-admin'] !== '1') {
+    if (typeof res.status === 'function') {
+      res.status(403).send?.('Forbidden');
+    } else {
+      res.statusCode = 403;
+      res.end?.('Forbidden');
+    }
+    return;
+  }
+
+  const body = {
+    cache: cacheStats(),
+    rateLimit: limiterStatus(),
+  };
+
+  if (typeof res.json === 'function') {
+    res.status?.(200).json(body);
+  } else {
+    res.statusCode = 200;
+    res.setHeader?.('Content-Type', 'application/json');
+    res.end?.(JSON.stringify(body));
+  }
+}

--- a/src/utils/kvCache.ts
+++ b/src/utils/kvCache.ts
@@ -1,0 +1,93 @@
+// Key-value cache with TTL per endpoint and deterministic keys
+
+interface CacheEntry<T = any> {
+  value: T;
+  expires: number;
+}
+
+// Map for cached entries
+const cache = new Map<string, CacheEntry>();
+
+// TTL configuration per endpoint (milliseconds)
+const ttls: Record<string, number> = {};
+
+let hits = 0;
+let misses = 0;
+
+const DEFAULT_TTL = 60_000; // 1 minute
+
+/**
+ * Create deterministic string representation of params
+ */
+function stableStringify(value: any): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  const keys = Object.keys(value).sort();
+  const props = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+  return `{${props.join(',')}}`;
+}
+
+function makeKey(endpoint: string, params: any): string {
+  return `${endpoint}:${stableStringify(params)}`;
+}
+
+export function setTTL(endpoint: string, ttl: number): void {
+  ttls[endpoint] = ttl;
+}
+
+export function get<T = any>(endpoint: string, params: any): T | undefined {
+  const key = makeKey(endpoint, params);
+  const entry = cache.get(key);
+  const now = Date.now();
+
+  if (entry && entry.expires > now) {
+    hits += 1;
+    return entry.value as T;
+  }
+
+  if (entry) {
+    cache.delete(key);
+  }
+  misses += 1;
+  return undefined;
+}
+
+export function set<T = any>(endpoint: string, params: any, value: T): void {
+  const ttl = ttls[endpoint] ?? DEFAULT_TTL;
+  const key = makeKey(endpoint, params);
+  cache.set(key, { value, expires: Date.now() + ttl });
+}
+
+export function stats() {
+  const total = hits + misses;
+  return {
+    hits,
+    misses,
+    hitRate: total === 0 ? 0 : hits / total,
+    size: cache.size,
+  };
+}
+
+// Utility to purge expired entries
+export function purgeExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of cache.entries()) {
+    if (entry.expires <= now) {
+      cache.delete(key);
+    }
+  }
+}
+
+export default {
+  setTTL,
+  get,
+  set,
+  stats,
+  purgeExpired,
+};


### PR DESCRIPTION
## Summary
- add KV cache with TTL and deterministic keys
- introduce token bucket rate limiter middleware
- expose admin API for cache and rate limit metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e7f9805883288f09d50738522d92