### PR TITLE
feat: add policy helper and enforce permissions

### DIFF
--- a/src/pages/api/secure.ts
+++ b/src/pages/api/secure.ts
@@ -1,0 +1,7 @@
+import { withPolicy } from '../../utils/policy';
+
+function handler(req: any, res: any): void {
+  res.json({ secret: true });
+}
+
+export default withPolicy('read', () => ({ type: 'secret' }))(handler);

--- a/src/templates/_common/scripts/commandPalette.ts
+++ b/src/templates/_common/scripts/commandPalette.ts
@@ -1,0 +1,19 @@
+import { can, PolicyUser } from '../../utils/policy';
+
+/**
+ * Disable command palette items user is not authorized to run.
+ * Command buttons should declare data-command, data-action and data-resource attributes.
+ */
+export function initCommandPalette(user: PolicyUser): void {
+  const elements = document.querySelectorAll<HTMLElement>('[data-command]');
+  elements.forEach((el) => {
+    const action = el.dataset.action || 'use';
+    const resource = el.dataset.resource || el.dataset.command || '';
+    if (!can(user, action, resource)) {
+      el.setAttribute('disabled', 'true');
+    }
+  });
+}
+
+export default { initCommandPalette };
+

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,12 @@
+import { initCommandPalette } from './commandPalette';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });
   }
+
+  const user = (window as any).user || {};
+  initCommandPalette(user);
 })();

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -4,15 +4,17 @@
 const { di } = require('../../di');
 const { TYPES } = require('../../types');
 const { safeQuotes, resolveFile } = require('../_common/scripts/template');
+const { can } = require('../../utils/policy');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
 
 const { config } = app;
+const user = config.user || {};
 
 const repositories = config.services.github.data.repositories;
 const repositoriesMore = config.templates.default.configuration.githubRepositoriesMore;
-const canShowMoreRepositories = repositoriesMore && repositoriesMore < repositories.length;
+const canShowMoreRepositories = repositoriesMore && repositoriesMore < repositories.length && can(user, 'view', 'repositories.more');
 
 function generateRepositoriesHtml(repositories) {
   var output = '';

--- a/src/utils/policy.ts
+++ b/src/utils/policy.ts
@@ -1,0 +1,87 @@
+export interface PolicyUser {
+  id?: string;
+  role?: string;
+  capabilities?: string[];
+  [key: string]: any;
+}
+
+export interface PolicyResource {
+  type?: string;
+  ownerId?: string;
+  public?: boolean;
+  [key: string]: any;
+}
+
+/**
+ * Simple attribute based access control helper using capability flags.
+ *
+ * @param user current user object
+ * @param action action attempting to perform (e.g. 'read', 'edit')
+ * @param resource resource type or object
+ */
+export function can(
+  user: PolicyUser | null | undefined,
+  action: string,
+  resource?: PolicyResource | string,
+): boolean {
+  if (!user) {
+    return action === 'read' && typeof resource !== 'string' && (resource as PolicyResource)?.public === true;
+  }
+
+  // administrators bypass checks
+  if (user.role === 'admin') {
+    return true;
+  }
+
+  const resType = typeof resource === 'string' ? resource : resource?.type || '';
+  const capability = `${action}:${resType}`;
+
+  // capability flags like "edit:post" or "read:repo"
+  if (user.capabilities?.includes(capability)) {
+    return true;
+  }
+
+  // owner can always access their own resource
+  if (
+    typeof resource !== 'string'
+    && resource?.ownerId !== undefined
+    && user.id !== undefined
+    && resource.ownerId === user.id
+  ) {
+    return true;
+  }
+
+  // public resources are readable by anyone
+  if (action === 'read' && typeof resource !== 'string' && resource?.public) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Wrap an API route handler with policy enforcement.
+ * Logs denied decisions for audit purposes.
+ */
+export function withPolicy(
+  action: string,
+  getResource?: (req: any) => PolicyResource | string,
+) {
+  return (handler: any) => (req: any, res: any, ...rest: any[]) => {
+    const resource = getResource ? getResource(req) : undefined;
+    if (!can(req.user, action, resource)) {
+      const userId = req.user?.id || 'anonymous';
+      const resType = typeof resource === 'string' ? resource : resource?.type || '';
+      // eslint-disable-next-line no-console
+      console.warn(`access denied: ${userId} cannot ${action} ${resType}`);
+      if (res?.status && res?.json) {
+        res.status(403).json({ error: 'forbidden' });
+      }
+      return undefined;
+    }
+    return handler(req, res, ...rest);
+  };
+}
+
+export default { can, withPolicy };
+

--- a/tests/utils/policy.test.ts
+++ b/tests/utils/policy.test.ts
@@ -1,0 +1,26 @@
+import { can } from '../../src/utils/policy';
+
+describe('policy.can', () => {
+  const user = { id: 'u1', capabilities: ['read:repo'] };
+
+  it('allows admin', () => {
+    expect(can({ role: 'admin' }, 'delete', 'repo')).toBeTruthy();
+  });
+
+  it('allows capability match', () => {
+    expect(can(user, 'read', 'repo')).toBeTruthy();
+  });
+
+  it('allows owner', () => {
+    expect(can({ id: 'u1' }, 'edit', { type: 'repo', ownerId: 'u1' })).toBeTruthy();
+  });
+
+  it('allows public read', () => {
+    expect(can(null, 'read', { type: 'repo', public: true })).toBeTruthy();
+  });
+
+  it('denies when no rule matches', () => {
+    expect(can(user, 'delete', 'repo')).toBeFalsy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `can` policy util with attribute-based access control and API wrapper
- disable command palette items and template controls when unauthorized
- audit access and protect example API route with policy helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e7f86ff08328a36f657c688de8fc