### PR TITLE
Add text sanitization and moderation queue

### DIFF
--- a/src/pages/admin/moderation/index.ejs
+++ b/src/pages/admin/moderation/index.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Moderation Queue</title>
+</head>
+<body>
+  <main>
+    <h1>Moderation Queue</h1>
+    <div id="queue"></div>
+  </main>
+  <script src="./index.ts"></script>
+</body>
+</html>

--- a/src/pages/admin/moderation/index.ts
+++ b/src/pages/admin/moderation/index.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import SanitizeText from '../../../utils/sanitizeText';
+
+interface QueueItem {
+  id: string;
+  content: string;
+}
+
+function renderQueue(items: QueueItem[]): void {
+  const container = document.getElementById('queue');
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  items.forEach((item) => {
+    const div = document.createElement('div');
+    div.className = 'queue-item';
+    div.textContent = SanitizeText.sanitize(item.content);
+
+    const approve = document.createElement('button');
+    approve.textContent = 'Approve';
+    approve.addEventListener('click', () => handleAction(item.id, true));
+
+    const remove = document.createElement('button');
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', () => handleAction(item.id, false));
+
+    div.appendChild(approve);
+    div.appendChild(remove);
+    container.appendChild(div);
+  });
+}
+
+async function loadQueue(): Promise<void> {
+  const resp = await fetch('/api/moderation/queue');
+  const data: QueueItem[] = await resp.json();
+  renderQueue(data);
+}
+
+async function handleAction(id: string, approve: boolean): Promise<void> {
+  await fetch('/api/moderation/queue', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, approve }),
+  });
+  await loadQueue();
+}
+
+loadQueue();

--- a/src/pages/api/moderation/queue.ts
+++ b/src/pages/api/moderation/queue.ts
@@ -1,0 +1,31 @@
+interface QueueItem {
+  id: string;
+  content: string;
+}
+
+const queue: QueueItem[] = [];
+
+export default function handler(req: any, res: any): void {
+  if (req.method === 'GET') {
+    res.status(200).json(queue);
+    return;
+  }
+
+  if (req.method === 'POST') {
+    queue.push(req.body as QueueItem);
+    res.status(201).json({ ok: true });
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.body as { id: string };
+    const index = queue.findIndex((item) => item.id === id);
+    if (index !== -1) {
+      queue.splice(index, 1);
+    }
+    res.status(204).end();
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -4,6 +4,7 @@
 const { di } = require('../../di');
 const { TYPES } = require('../../types');
 const { safeQuotes, resolveFile } = require('../_common/scripts/template');
+const { default: SanitizeText } = require('../../utils/sanitizeText');
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
@@ -18,13 +19,13 @@ function generateRepositoriesHtml(repositories) {
   var output = '';
 
   for (var i = 0; i < repositories.length; i++) {
-    output +=
-      `<a href="${repositories[i].html_url}" class="repository" target="_blank">
-        <div class="repository__name">${repositories[i].full_name}</div>
-        <div class="repository__description">
-          <p>${repositories[i].description || '-'}</p>
-        </div>
-        <div class="repository__footer">
+      output +=
+        `<a href="${repositories[i].html_url}" class="repository" target="_blank" rel="noopener noreferrer">
+          <div class="repository__name">${SanitizeText.sanitize(repositories[i].full_name)}</div>
+          <div class="repository__description">
+            <p>${SanitizeText.sanitize(repositories[i].description || '-')}</p>
+          </div>
+          <div class="repository__footer">
           <div class="repository__footer__language">
             <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="code"><polyline fill="none" stroke="#000" stroke-width="1.01" points="13,4 19,10 13,16"></polyline><polyline fill="none" stroke="#000" stroke-width="1.01" points="7,4 1,10 7,16"></polyline></svg>
             <span>${repositories[i].language || '-'}</span>
@@ -62,17 +63,17 @@ function generateRepositoriesHtml(repositories) {
   <div class="header__background background--image"></div>
   <div class="header__wrap">
     <div class="header__wrap__image avatar--image"></div>
-    <h1 class="header__wrap__name"><%= `${config.data.first_name} ${config.data.last_name}` %></h1>
+      <h1 class="header__wrap__name"><%= SanitizeText.sanitize(`${config.data.first_name} ${config.data.last_name}`) %></h1>
     <% if (config.data.position) { %>
-      <span class="header__wrap__position"><%= config.data.position %></span>
+        <span class="header__wrap__position"><%= SanitizeText.sanitize(config.data.position) %></span>
     <% } %>
     <% if (config.data.links.length > 0) { %>
       <div class="header__wrap__social">
-        <% for (const link of config.data.links) { %>
-          <a href="<%= link.url %>" title="<%= safeQuotes(link.name) %>" rel="nofollow">
-            <%= require(`!!svg-inline-loader!../_common/assets/icons/${link.name}.svg`) %>
-          </a>
-        <% } %>
+          <% for (const link of config.data.links) { if (SanitizeText.isUrlAllowed(link.url)) { %>
+            <a href="<%= link.url %>" title="<%= safeQuotes(SanitizeText.sanitize(link.name)) %>" rel="noopener noreferrer nofollow" target="_blank">
+              <%= require(`!!svg-inline-loader!../_common/assets/icons/${link.name}.svg`) %>
+            </a>
+          <% } } %>
       </div>
     <% } %>
   </div>

--- a/src/utils/sanitizeText.ts
+++ b/src/utils/sanitizeText.ts
@@ -1,0 +1,50 @@
+import { URL } from 'url';
+
+const PROFANE_WORDS = ['damn', 'hell', 'shit', 'fuck'];
+export const ALLOWED_DOMAINS = [
+  'github.com',
+  'twitter.com',
+  'linkedin.com',
+  'medium.com',
+];
+
+export default class SanitizeText {
+  static stripProfanity(text: string): string {
+    if (!text) {
+      return '';
+    }
+    const regex = new RegExp(`\\b(${PROFANE_WORDS.join('|')})\\b`, 'gi');
+    return text.replace(regex, '****');
+  }
+
+  static stripUnsafeUrls(text: string): string {
+    if (!text) {
+      return '';
+    }
+    return text.replace(/https?:[^\s]+/gi, (url) => {
+      try {
+        const hostname = new URL(url).hostname.replace(/^www\./, '');
+        if (ALLOWED_DOMAINS.includes(hostname)) {
+          return url;
+        }
+      } catch (e) {
+        // ignore
+      }
+      return '';
+    });
+  }
+
+  static sanitize(text: string): string {
+    const noProfanity = SanitizeText.stripProfanity(text);
+    return SanitizeText.stripUnsafeUrls(noProfanity);
+  }
+
+  static isUrlAllowed(url: string): boolean {
+    try {
+      const hostname = new URL(url).hostname.replace(/^www\./, '');
+      return ALLOWED_DOMAINS.includes(hostname);
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/tests/utils/sanitizeText.test.ts
+++ b/tests/utils/sanitizeText.test.ts
@@ -1,0 +1,19 @@
+import SanitizeText from '../../src/utils/sanitizeText';
+
+describe('SanitizeText', () => {
+  it('replaces profanity with asterisks', () => {
+    const result = SanitizeText.sanitize('hello shit world');
+    expect(result).toBe('hello **** world');
+  });
+
+  it('removes urls not in allow list', () => {
+    const result = SanitizeText.sanitize('visit http://malicious.com now');
+    expect(result).toBe('visit  now');
+  });
+
+  it('keeps allowed urls', () => {
+    const text = 'check https://github.com/repo';
+    const result = SanitizeText.sanitize(text);
+    expect(result).toBe(text);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize text and URLs with allow-list
- enforce safe link attributes
- add moderation queue API and admin UI

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e7facf548328bcbb8e8822412c56