### PR TITLE
feat: add mobile haptics, lazy sounds, and accessibility settings

### DIFF
--- a/src/pages/settings/accessibility.tsx
+++ b/src/pages/settings/accessibility.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+const motionQuery = '(prefers-reduced-motion: reduce)';
+const transparencyQuery = '(prefers-reduced-transparency: reduce)';
+
+export default function AccessibilitySettings(): JSX.Element {
+  const [reduceMotion, setReduceMotion] = useState<boolean>(() =>
+    typeof window !== 'undefined' && window.matchMedia(motionQuery).matches,
+  );
+  const [reduceTransparency, setReduceTransparency] = useState<boolean>(() =>
+    typeof window !== 'undefined' && window.matchMedia(transparencyQuery).matches,
+  );
+
+  useEffect(() => {
+    document.body.classList.toggle('reduced-motion', reduceMotion);
+    document.body.classList.toggle('reduced-transparency', reduceTransparency);
+  }, [reduceMotion, reduceTransparency]);
+
+  return (
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          checked={reduceMotion}
+          onChange={(e) => setReduceMotion(e.target.checked)}
+        />
+        Reduce motion
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={reduceTransparency}
+          onChange={(e) => setReduceTransparency(e.target.checked)}
+        />
+        Reduce transparency
+      </label>
+    </div>
+  );
+}
+

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -1,0 +1,29 @@
+// Utility helpers for triggering lightweight haptic feedback on supported
+// mobile devices using the Vibration API.
+
+const canVibrate = typeof navigator !== 'undefined' && !!navigator.vibrate;
+
+const vibration = (pattern: number | number[]): void => {
+  if (canVibrate) {
+    navigator.vibrate(pattern);
+  }
+};
+
+const Haptics = {
+  /** Triggered while an item is being dragged. */
+  drag(): void {
+    vibration(5);
+  },
+
+  /** Triggered when an item is dropped. */
+  drop(): void {
+    vibration([0, 15, 10, 15]);
+  },
+
+  /** Triggered on success confirmations. */
+  success(): void {
+    vibration([20, 20, 20]);
+  },
+};
+
+export default Haptics;

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -1,0 +1,41 @@
+// Simple sound helper that lazily loads soft UI sounds.
+// Sounds are muted by default until `unmute` is called.
+
+type SoundKey = 'tap' | 'success';
+
+const sources: Record<SoundKey, string> = {
+  tap: '/sounds/tap.mp3',
+  success: '/sounds/success.mp3',
+};
+
+const cache: Partial<Record<SoundKey, HTMLAudioElement>> = {};
+let muted = true;
+
+const load = (key: SoundKey): HTMLAudioElement => {
+  if (!cache[key]) {
+    cache[key] = new Audio(sources[key]);
+  }
+
+  return cache[key]!;
+};
+
+const Sounds = {
+  play(key: SoundKey): void {
+    if (muted) {
+      return;
+    }
+
+    const audio = load(key);
+    audio.play().catch(() => undefined);
+  },
+
+  mute(): void {
+    muted = true;
+  },
+
+  unmute(): void {
+    muted = false;
+  },
+};
+
+export default Sounds;


### PR DESCRIPTION
## Summary
- add vibration feedback utilities for drag, drop, and success actions
- introduce lazy-loaded UI sound helper, muted by default
- add accessibility settings page honoring reduced motion & transparency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e7fba46c8328a80d1b9533b0d1db