### PR TITLE
Add secure file previewer components with streaming text support

### DIFF
--- a/src/components/previewers/BasePreviewer.ts
+++ b/src/components/previewers/BasePreviewer.ts
@@ -1,0 +1,26 @@
+export default abstract class BasePreviewer {
+  protected readonly container: HTMLElement;
+
+  protected readonly chrome: HTMLElement;
+
+  protected readonly content: HTMLElement;
+
+  constructor(container?: HTMLElement) {
+    this.container = container || document.createElement('div');
+    this.container.className = 'previewer';
+
+    this.chrome = document.createElement('div');
+    this.chrome.className = 'previewer-chrome';
+    this.container.appendChild(this.chrome);
+
+    this.content = document.createElement('div');
+    this.content.className = 'previewer-content';
+    this.chrome.appendChild(this.content);
+  }
+
+  public get element(): HTMLElement {
+    return this.container;
+  }
+
+  public abstract preview(input: Blob | string | object): Promise<void> | void;
+}

--- a/src/components/previewers/ImagePreviewer.ts
+++ b/src/components/previewers/ImagePreviewer.ts
@@ -1,0 +1,14 @@
+import BasePreviewer from './BasePreviewer';
+
+export default class ImagePreviewer extends BasePreviewer {
+  public async preview(input: Blob | string): Promise<void> {
+    const img = document.createElement('img');
+    img.className = 'previewer-image';
+    if (typeof input === 'string') {
+      img.src = input;
+    } else {
+      img.src = URL.createObjectURL(input);
+    }
+    this.content.appendChild(img);
+  }
+}

--- a/src/components/previewers/JsonPreviewer.ts
+++ b/src/components/previewers/JsonPreviewer.ts
@@ -1,0 +1,24 @@
+import TextPreviewer from './TextPreviewer';
+
+export default class JsonPreviewer extends TextPreviewer {
+  public async preview(input: Blob | string | object): Promise<void> {
+    if (typeof input === 'object' && !(input instanceof Blob)) {
+      const pre = document.createElement('pre');
+      pre.className = 'previewer-json';
+      pre.textContent = JSON.stringify(input, null, 2);
+      this.content.appendChild(pre);
+      return;
+    }
+
+    const text = typeof input === 'string' ? input : await input.text();
+    const pre = document.createElement('pre');
+    pre.className = 'previewer-json';
+    try {
+      const json = JSON.parse(text);
+      pre.textContent = JSON.stringify(json, null, 2);
+    } catch (e) {
+      pre.textContent = text;
+    }
+    this.content.appendChild(pre);
+  }
+}

--- a/src/components/previewers/PreviewerFactory.ts
+++ b/src/components/previewers/PreviewerFactory.ts
@@ -1,0 +1,23 @@
+import BasePreviewer from './BasePreviewer';
+import ImagePreviewer from './ImagePreviewer';
+import VideoPreviewer from './VideoPreviewer';
+import TextPreviewer from './TextPreviewer';
+import JsonPreviewer from './JsonPreviewer';
+import UnsafePreviewer from './UnsafePreviewer';
+import { isSafeType } from './SecurityGuard';
+
+export default function createPreviewer(type: string, container?: HTMLElement): BasePreviewer {
+  if (!isSafeType(type)) {
+    return new UnsafePreviewer(container);
+  }
+  if (type.startsWith('image/')) {
+    return new ImagePreviewer(container);
+  }
+  if (type.startsWith('video/')) {
+    return new VideoPreviewer(container);
+  }
+  if (type === 'application/json') {
+    return new JsonPreviewer(container);
+  }
+  return new TextPreviewer(container);
+}

--- a/src/components/previewers/SecurityGuard.ts
+++ b/src/components/previewers/SecurityGuard.ts
@@ -1,0 +1,24 @@
+export const DANGEROUS_TYPES = new Set([
+  'text/html',
+  'application/javascript',
+  'application/x-msdownload',
+  'application/x-msdos-program',
+  'application/x-sh',
+  'application/x-bat',
+]);
+
+export function isSafeType(type: string): boolean {
+  if (!type || DANGEROUS_TYPES.has(type)) {
+    return false;
+  }
+  if (type.startsWith('image/') || type.startsWith('video/')) {
+    return true;
+  }
+  if (type === 'text/plain' || type.startsWith('text/')) {
+    return true;
+  }
+  if (type === 'application/json') {
+    return true;
+  }
+  return false;
+}

--- a/src/components/previewers/TextPreviewer.ts
+++ b/src/components/previewers/TextPreviewer.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-await-in-loop */
+import BasePreviewer from './BasePreviewer';
+
+export default class TextPreviewer extends BasePreviewer {
+  public async preview(input: Blob | string): Promise<void> {
+    const pre = document.createElement('pre');
+    pre.className = 'previewer-text';
+    this.content.appendChild(pre);
+
+    if (typeof input === 'string') {
+      pre.textContent = input;
+      return;
+    }
+
+    const reader = input.stream().getReader();
+    const decoder = new TextDecoder();
+    let result = await reader.read();
+    while (!result.done) {
+      pre.textContent += decoder.decode(result.value, { stream: true });
+      result = await reader.read();
+    }
+    pre.textContent += decoder.decode();
+  }
+}

--- a/src/components/previewers/UnsafePreviewer.ts
+++ b/src/components/previewers/UnsafePreviewer.ts
@@ -1,0 +1,10 @@
+import BasePreviewer from './BasePreviewer';
+
+export default class UnsafePreviewer extends BasePreviewer {
+  public async preview(): Promise<void> {
+    const div = document.createElement('div');
+    div.className = 'previewer-unsafe';
+    div.textContent = 'Preview disabled for security reasons.';
+    this.content.appendChild(div);
+  }
+}

--- a/src/components/previewers/VideoPreviewer.ts
+++ b/src/components/previewers/VideoPreviewer.ts
@@ -1,0 +1,15 @@
+import BasePreviewer from './BasePreviewer';
+
+export default class VideoPreviewer extends BasePreviewer {
+  public async preview(input: Blob | string): Promise<void> {
+    const video = document.createElement('video');
+    video.className = 'previewer-video';
+    video.controls = true;
+    if (typeof input === 'string') {
+      video.src = input;
+    } else {
+      video.src = URL.createObjectURL(input);
+    }
+    this.content.appendChild(video);
+  }
+}

--- a/src/components/previewers/index.ts
+++ b/src/components/previewers/index.ts
@@ -1,0 +1,8 @@
+export { default as BasePreviewer } from './BasePreviewer';
+export { default as ImagePreviewer } from './ImagePreviewer';
+export { default as VideoPreviewer } from './VideoPreviewer';
+export { default as TextPreviewer } from './TextPreviewer';
+export { default as JsonPreviewer } from './JsonPreviewer';
+export { default as UnsafePreviewer } from './UnsafePreviewer';
+export { isSafeType, DANGEROUS_TYPES } from './SecurityGuard';
+export { default as createPreviewer } from './PreviewerFactory';

--- a/tests/components/SecurityGuard.test.ts
+++ b/tests/components/SecurityGuard.test.ts
@@ -1,0 +1,16 @@
+import { isSafeType, DANGEROUS_TYPES } from '../../src/components/previewers';
+
+describe('SecurityGuard', () => {
+  it('allows known safe types', () => {
+    expect(isSafeType('image/png')).toBe(true);
+    expect(isSafeType('video/mp4')).toBe(true);
+    expect(isSafeType('text/plain')).toBe(true);
+    expect(isSafeType('application/json')).toBe(true);
+  });
+
+  it('rejects dangerous types', () => {
+    DANGEROUS_TYPES.forEach((type) => {
+      expect(isSafeType(type)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable base previewer and implementations for image, video, text, and JSON
- stream large text files in chunks
- guard against dangerous MIME types and show a safe placeholder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3e8027b608328a5b2e11667c955e7