### PR TITLE
Add skeleton loaders with delayed shimmer

### DIFF
--- a/src/components/Skeletons/ConfigSkeleton.ts
+++ b/src/components/Skeletons/ConfigSkeleton.ts
@@ -1,0 +1,16 @@
+export default function ConfigSkeleton(): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'skeleton-config';
+
+  const title = document.createElement('div');
+  title.className = 'skeleton skeleton-title';
+  root.appendChild(title);
+
+  for (let i = 0; i < 3; i += 1) {
+    const line = document.createElement('div');
+    line.className = 'skeleton skeleton-line';
+    root.appendChild(line);
+  }
+
+  return root;
+}

--- a/src/components/Skeletons/HomeSkeleton.ts
+++ b/src/components/Skeletons/HomeSkeleton.ts
@@ -1,0 +1,24 @@
+export default function HomeSkeleton(): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'skeleton-home';
+
+  const avatar = document.createElement('div');
+  avatar.className = 'skeleton skeleton-avatar';
+  root.appendChild(avatar);
+
+  const title = document.createElement('div');
+  title.className = 'skeleton skeleton-title';
+  root.appendChild(title);
+
+  const subtitle = document.createElement('div');
+  subtitle.className = 'skeleton skeleton-subtitle';
+  root.appendChild(subtitle);
+
+  for (let i = 0; i < 3; i += 1) {
+    const repo = document.createElement('div');
+    repo.className = 'skeleton skeleton-repository';
+    root.appendChild(repo);
+  }
+
+  return root;
+}

--- a/src/components/Skeletons/index.ts
+++ b/src/components/Skeletons/index.ts
@@ -1,0 +1,3 @@
+export { default as HomeSkeleton } from './HomeSkeleton';
+export { default as ConfigSkeleton } from './ConfigSkeleton';
+export { withDelayedSkeleton } from './withDelayedSkeleton';

--- a/src/components/Skeletons/styles.scss
+++ b/src/components/Skeletons/styles.scss
@@ -1,0 +1,69 @@
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: #e0e0e0;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 150%;
+  height: 100%;
+  background-image: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+  animation: skeleton-shimmer 1.2s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}
+
+.skeleton-home {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.skeleton-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+}
+
+.skeleton-title {
+  width: 60%;
+  height: 20px;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton-subtitle {
+  width: 40%;
+  height: 16px;
+  margin-bottom: 1rem;
+}
+
+.skeleton-repository {
+  width: 100%;
+  height: 80px;
+  margin-top: 1rem;
+}
+
+.skeleton-config {
+  padding: 1rem;
+}
+
+.skeleton-line {
+  width: 100%;
+  height: 20px;
+  margin-top: 0.75rem;
+}

--- a/src/components/Skeletons/withDelayedSkeleton.ts
+++ b/src/components/Skeletons/withDelayedSkeleton.ts
@@ -1,0 +1,17 @@
+export function withDelayedSkeleton<T>(
+  loader: () => Promise<T>,
+  skeleton: HTMLElement,
+  delay = 200,
+): Promise<T> {
+  const container = document.body;
+  const timer: number = window.setTimeout(() => {
+    container.appendChild(skeleton);
+  }, delay);
+
+  return loader().finally(() => {
+    clearTimeout(timer);
+    if (skeleton.parentNode) {
+      skeleton.parentNode.removeChild(skeleton);
+    }
+  });
+}

--- a/src/pages/config/index.scss
+++ b/src/pages/config/index.scss
@@ -1,1 +1,2 @@
+@import "../../components/Skeletons/styles";
 @import "styles/global";

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,12 @@
+import { ConfigSkeleton, withDelayedSkeleton } from '../../components/Skeletons';
+
+withDelayedSkeleton(
+  () => new Promise<void>((resolve) => {
+    window.addEventListener('load', () => resolve());
+  }),
+  ConfigSkeleton(),
+);
+
 (() => {
   console.log('dev');
 })();

--- a/src/templates/_common/styles/index.scss
+++ b/src/templates/_common/styles/index.scss
@@ -1,1 +1,2 @@
 @import "~normalize.css";
+@import "../../components/Skeletons/styles";

--- a/src/templates/default/index.ts
+++ b/src/templates/default/index.ts
@@ -1,1 +1,9 @@
 import '../_common/scripts';
+import { HomeSkeleton, withDelayedSkeleton } from '../../components/Skeletons';
+
+withDelayedSkeleton(
+  () => new Promise<void>((resolve) => {
+    window.addEventListener('load', () => resolve());
+  }),
+  HomeSkeleton(),
+);


### PR DESCRIPTION
## Summary
- add layout skeleton components for home and config routes
- show skeletons only after a short loading delay
- add shimmer animation respecting `prefers-reduced-motion`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b3e80321ac8328a2f55c0fa1f5c026