### PR TITLE
feat: optimize media based on network metrics

### DIFF
--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,55 @@
+import { getNetworkInformation, sendNetworkTelemetry } from '../../../utils/network';
+
 (() => {
-  if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
-    window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/sw.js');
+  const metrics = getNetworkInformation();
+  const isSlow = Boolean(metrics.saveData)
+    || (metrics.downlink !== undefined && metrics.downlink < 1.5)
+    || (metrics.rtt !== undefined && metrics.rtt > 300);
+
+  const optimizeImages = (): void => {
+    document.querySelectorAll<HTMLImageElement>('img[data-src-low][data-src-high]').forEach((img) => {
+      const low = img.getAttribute('data-src-low');
+      const high = img.getAttribute('data-src-high');
+      if (isSlow) {
+        if (low) {
+          img.setAttribute('src', low);
+        }
+      } else if (high) {
+        img.setAttribute('src', high);
+      }
     });
-  }
+  };
+
+  const optimizeVideos = (): void => {
+    document.querySelectorAll<HTMLVideoElement>('video').forEach((video) => {
+      video.setAttribute('preload', isSlow ? 'none' : 'auto');
+      const low = video.getAttribute('data-src-low');
+      const high = video.getAttribute('data-src-high');
+      const source = isSlow ? low : high;
+      if (source) {
+        video.setAttribute('src', source);
+      }
+    });
+  };
+
+  window.addEventListener('load', () => {
+    optimizeImages();
+    optimizeVideos();
+
+    if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
+      navigator.serviceWorker.register('/sw.js');
+    }
+
+    const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
+    const duration = navigation ? navigation.duration : performance.now();
+    sendNetworkTelemetry('load', duration, metrics);
+  });
+
+  window.addEventListener('click', () => {
+    const start = performance.now();
+    requestAnimationFrame(() => {
+      const duration = performance.now() - start;
+      sendNetworkTelemetry('interaction', duration, metrics);
+    });
+  }, { once: true });
 })();

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,65 @@
+export interface NetworkInformationMetrics {
+  downlink?: number;
+  rtt?: number;
+  saveData?: boolean;
+}
+
+function getConnection(): any {
+  if (typeof navigator === 'undefined') {
+    return undefined;
+  }
+
+  return (navigator as any).connection
+    || (navigator as any).mozConnection
+    || (navigator as any).webkitConnection;
+}
+
+export function getNetworkInformation(): NetworkInformationMetrics {
+  const connection = getConnection();
+
+  if (!connection) {
+    return { downlink: undefined, rtt: undefined, saveData: undefined };
+  }
+
+  const { downlink, rtt, saveData } = connection;
+  return { downlink, rtt, saveData };
+}
+
+export function onNetworkInformationChange(cb: (info: NetworkInformationMetrics) => void): void {
+  const connection = getConnection();
+  if (!connection) {
+    return;
+  }
+
+  const handler = (): void => {
+    cb(getNetworkInformation());
+  };
+
+  connection.addEventListener('change', handler);
+}
+
+export function sendNetworkTelemetry(
+  event: string,
+  duration: number,
+  info: NetworkInformationMetrics,
+): void {
+  const body = JSON.stringify({ event, duration, ...info });
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon('/telemetry', body);
+    return;
+  }
+
+  try {
+    fetch('/telemetry', {
+      method: 'POST',
+      body,
+      keepalive: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (e) {
+    // ignore telemetry errors
+  }
+}

--- a/tests/utils/network.test.ts
+++ b/tests/utils/network.test.ts
@@ -1,0 +1,20 @@
+import { getNetworkInformation } from '../../src/utils/network';
+
+describe('network utils', () => {
+  afterEach(() => {
+    delete (global as any).navigator;
+  });
+
+  it('returns undefined metrics without connection', () => {
+    const info = getNetworkInformation();
+    expect(info).toEqual({ downlink: undefined, rtt: undefined, saveData: undefined });
+  });
+
+  it('reads metrics from navigator.connection', () => {
+    (global as any).navigator = {
+      connection: { downlink: 1.5, rtt: 100, saveData: false },
+    };
+    const info = getNetworkInformation();
+    expect(info).toEqual({ downlink: 1.5, rtt: 100, saveData: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add network utility to read connection metrics and report telemetry
- adjust media quality and preload using network conditions
- log interaction latency with associated network info

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e803e4c4832885b6be3d35487518