### PR TITLE
feat: add policy helper with capability checks

### DIFF
--- a/src/components/permissions.tsx
+++ b/src/components/permissions.tsx
@@ -1,0 +1,27 @@
+import can from '../lib/policy/can';
+
+export function hideIfCant<T>(user: any, action: string, resource: any, element: T): T | null {
+  return can(user, action, resource) ? element : null;
+}
+
+export function disableIfCant<T extends { disabled?: boolean }>(
+  user: any,
+  action: string,
+  resource: any,
+  element: T,
+): T {
+  if (can(user, action, resource)) {
+    return element;
+  }
+  return { ...element, disabled: true };
+}
+
+export interface CommandAction {
+  action: string;
+  resource?: any;
+  [key: string]: any;
+}
+
+export function filterCommandActions(user: any, actions: CommandAction[]): CommandAction[] {
+  return actions.filter((a) => can(user, a.action, a.resource));
+}

--- a/src/lib/policy/can.ts
+++ b/src/lib/policy/can.ts
@@ -1,0 +1,62 @@
+export interface User {
+  id?: string;
+  attributes?: Record<string, any>;
+  capabilities?: Record<string, boolean>;
+}
+
+export interface Resource {
+  ownerId?: string;
+  attributes?: Record<string, any>;
+  requiredAttributes?: Record<string, any>;
+  capability?: string;
+}
+
+const capabilityFlags: Record<string, boolean> = {};
+
+export function setCapabilityFlag(name: string, enabled: boolean): void {
+  capabilityFlags[name] = enabled;
+}
+
+export function getCapabilityFlag(name: string): boolean | undefined {
+  return capabilityFlags[name];
+}
+
+export function clearCapabilityFlags(): void {
+  Object.keys(capabilityFlags).forEach((k) => delete capabilityFlags[k]);
+}
+
+export function can(
+  user: User | null,
+  action: string,
+  resource?: Resource,
+): boolean {
+  const capability = resource?.capability || action;
+
+  if (capability && capabilityFlags[capability] === false) {
+    return false;
+  }
+
+  if (user?.capabilities && capability) {
+    const userCap = user.capabilities[capability];
+    if (userCap === false) {
+      return false;
+    }
+  }
+
+  if (resource?.ownerId && user?.id && resource.ownerId !== user.id) {
+    return false;
+  }
+
+  if (resource?.requiredAttributes) {
+    const attrs = user?.attributes || {};
+    for (const [key, value] of Object.entries(resource.requiredAttributes)) {
+      if (attrs[key] !== value) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+export default can;

--- a/src/server/routes/secure.ts
+++ b/src/server/routes/secure.ts
@@ -1,0 +1,23 @@
+import can from '../../lib/policy/can';
+
+export type Handler = (req: any, res: any) => any;
+
+export function secureRoute(action: string, resource: any, handler: Handler): Handler {
+  return (req: any, res: any) => {
+    const user = req?.user || null;
+    if (can(user, action, resource)) {
+      return handler(req, res);
+    }
+    // Log denied decision
+    console.warn(`Access denied for action "${action}"`);
+    if (res) {
+      res.statusCode = 403;
+      if (typeof res.end === 'function') {
+        res.end();
+      }
+    }
+    return undefined;
+  };
+}
+
+export default secureRoute;

--- a/tests/policy/can.test.ts
+++ b/tests/policy/can.test.ts
@@ -1,0 +1,49 @@
+import can, { setCapabilityFlag, clearCapabilityFlags } from '../../src/lib/policy/can';
+import secureRoute from '../../src/server/routes/secure';
+import { hideIfCant, disableIfCant, filterCommandActions } from '../../src/components/permissions';
+
+describe('capability flag integration', () => {
+  afterEach(() => {
+    clearCapabilityFlags();
+  });
+
+  const user = { id: '1', attributes: { role: 'admin' } };
+  const resource = { ownerId: '1', capability: 'edit' };
+
+  test('toggling capability flag affects can, routes, and UI', () => {
+    setCapabilityFlag('edit', true);
+    expect(can(user, 'edit', resource)).toBe(true);
+
+    const handler = jest.fn();
+    const req: any = { user };
+    const res: any = {};
+    secureRoute('edit', resource, handler)(req, res);
+    expect(handler).toHaveBeenCalled();
+
+    expect(hideIfCant(user, 'edit', resource, 'element')).toBe('element');
+    expect(disableIfCant(user, 'edit', resource, { disabled: false })).toEqual({ disabled: false });
+
+    setCapabilityFlag('edit', false);
+    expect(can(user, 'edit', resource)).toBe(false);
+
+    const deniedHandler = jest.fn();
+    const deniedReq: any = { user };
+    const deniedRes: any = { statusCode: 200, end: jest.fn() };
+    const logSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    secureRoute('edit', resource, deniedHandler)(deniedReq, deniedRes);
+    expect(deniedHandler).not.toHaveBeenCalled();
+    expect(deniedRes.statusCode).toBe(403);
+    expect(logSpy).toHaveBeenCalled();
+    logSpy.mockRestore();
+
+    expect(hideIfCant(user, 'edit', resource, 'element')).toBeNull();
+    expect(disableIfCant(user, 'edit', resource, { disabled: false })).toEqual({ disabled: true });
+    const actions = [
+      { action: 'edit', resource, id: 1 },
+      { action: 'view', resource: { ownerId: '1' }, id: 2 },
+    ];
+    expect(filterCommandActions(user, actions)).toEqual([
+      { action: 'view', resource: { ownerId: '1' }, id: 2 },
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "module": "commonjs",
     "moduleResolution": "node",
+    "jsx": "react",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add `can` helper with attribute and capability flag checks
- secure server routes via wrapper with denial logging
- expose UI utilities to hide/disable elements and filter command actions
- test integration to ensure capability flag toggling updates UI and server behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eedc12748328895fb5b99b2761c8