### PR TITLE
feat: add undo history service and toast component

### DIFF
--- a/src/components/UndoToast.tsx
+++ b/src/components/UndoToast.tsx
@@ -1,0 +1,68 @@
+/**
+ * A small toast notification presenting the user with the option to undo the
+ * latest action.  The toast automatically disappears after a short period of
+ * time unless the user clicks the **Undo** button.
+ *
+ * The implementation purposefully avoids any dependency on a specific UI
+ * framework (React/Angular/etc.) so that it can be used in the vanilla JS
+ * environment of this project as well as within tests running in JSDOM.
+ */
+export interface UndoToastOptions {
+  /** Callback invoked when the user clicks the *Undo* button. */
+  onUndo: () => void;
+  /** Optional message displayed inside the toast. */
+  message?: string;
+  /**
+   * How long the toast should remain visible in milliseconds.  Defaults to
+   * `3000` (3 seconds).
+   */
+  duration?: number;
+}
+
+export default class UndoToast {
+  private element: HTMLDivElement;
+
+  private timer = 0;
+
+  constructor(options: UndoToastOptions) {
+    const { onUndo, message = 'Action completed', duration = 3000 } = options;
+
+    // Create basic markup: <div class="undo-toast"><span/> <button/></div>
+    const root = document.createElement('div');
+    root.className = 'undo-toast';
+
+    const span = document.createElement('span');
+    span.textContent = message;
+    root.appendChild(span);
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Undo';
+    btn.addEventListener('click', () => {
+      this.hide();
+      onUndo();
+    });
+    root.appendChild(btn);
+
+    // Append to document body.
+    document.body.appendChild(root);
+
+    // Store and start auto-dismiss timer.
+    this.element = root;
+    this.timer = window.setTimeout(() => this.hide(), duration);
+  }
+
+  /**
+   * Removes the toast from the DOM and clears any remaining timers.
+   */
+  hide(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = 0;
+    }
+
+    if (this.element.parentElement) {
+      this.element.parentElement.removeChild(this.element);
+    }
+  }
+}
+

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,42 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import History, { HistoryService } from '../../services/history';
 
+/**
+ * Development server helpers.
+ *
+ * The server exposes a small API that can be used by the client during
+ * development.  In particular we expose an `/undo` endpoint that rolls back
+ * actions recorded in the {@link HistoryService}.  The endpoint accepts an
+ * optional `steps` property in the request body describing how many operations
+ * should be reverted (default is `1`).
+ */
 export default class Server {
+  private history: HistoryService;
+
+  constructor(history: HistoryService = History) {
+    this.history = history;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);
     // });
+
+    // Endpoint used by the client to undo previously executed operations.  The
+    // operations themselves are recorded via the History service which stores
+    // a stack of compensating callbacks.  When this endpoint is triggered we
+    // simply pop the required number of callbacks and execute them.
+    app.post('/undo', async (req: any, res: any) => {
+      const steps = typeof req.body?.steps === 'number' ? req.body.steps : 1;
+
+      await this.history.undo(steps);
+
+      res.json({ success: true, remaining: this.history.length });
+    });
   }
 }
+

--- a/src/services/history.ts
+++ b/src/services/history.ts
@@ -1,0 +1,68 @@
+/**
+ * A reversible operation represented as a callback. The callback can be
+ * synchronous or return a promise.
+ */
+export type HistoryOperation = () => void | Promise<void>;
+
+/**
+ * Service that stores a stack of reversible operations. Each time an action is
+ * executed, a compensating callback can be recorded via {@link record} or
+ * {@link execute}.  The service allows the latest operations to be reverted in
+ * a LIFO order using {@link undo}.  Multiple steps can be reverted at once by
+ * passing a `steps` argument to {@link undo}.
+ */
+export class HistoryService {
+  private stack: HistoryOperation[] = [];
+
+  /**
+   * Number of operations currently stored in the history stack.
+   */
+  get length(): number {
+    return this.stack.length;
+  }
+
+  /**
+   * Clears all stored history entries.
+   */
+  clear(): void {
+    this.stack = [];
+  }
+
+  /**
+   * Records a compensating operation.  The operation will be executed when
+   * {@link undo} is called.
+   */
+  record(operation: HistoryOperation): void {
+    this.stack.push(operation);
+  }
+
+  /**
+   * Executes an action and records its undo callback. This helper simplifies
+   * scenarios where the action and its compensation are defined together.
+   */
+  async execute(action: HistoryOperation, undo: HistoryOperation): Promise<void> {
+    await action();
+    this.record(undo);
+  }
+
+  /**
+   * Undoes the last `steps` operations (defaults to one). Operations are
+   * executed in reverse order of their registration. The method awaits each
+   * callback which allows both synchronous and asynchronous undo handlers.
+   */
+  async undo(steps = 1): Promise<void> {
+    while (steps > 0 && this.stack.length > 0) {
+      const operation = this.stack.pop();
+      // eslint-disable-next-line no-await-in-loop
+      await operation?.();
+      steps -= 1;
+    }
+  }
+}
+
+// A default instance exported for convenience.  Most consumers of the service
+// use a singleton history stack.
+const defaultHistory = new HistoryService();
+
+export default defaultHistory;
+

--- a/tests/components/UndoToast.test.tsx
+++ b/tests/components/UndoToast.test.tsx
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+
+import UndoToast from '../../src/components/UndoToast';
+
+describe('UndoToast component', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('removes itself after the duration', () => {
+    jest.useFakeTimers();
+    new UndoToast({ onUndo: () => {}, message: 'Saved', duration: 100 });
+
+    expect(document.querySelector('.undo-toast')).not.toBeNull();
+
+    jest.advanceTimersByTime(150);
+
+    expect(document.querySelector('.undo-toast')).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('triggers undo callback when button clicked', () => {
+    jest.useFakeTimers();
+    const fn = jest.fn();
+    new UndoToast({ onUndo: fn, message: 'Saved', duration: 1000 });
+
+    const button = document.querySelector('.undo-toast button') as HTMLButtonElement;
+    button.click();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.undo-toast')).toBeNull();
+    jest.useRealTimers();
+  });
+});
+

--- a/tests/modules/ServerUndo.test.ts
+++ b/tests/modules/ServerUndo.test.ts
@@ -1,0 +1,46 @@
+import express from 'express';
+import http from 'http';
+import Server from '../../src/modules/server/Server';
+import { HistoryService } from '../../src/services/history';
+
+describe('Server undo endpoint', () => {
+  it('calls history.undo when /undo endpoint hit', async () => {
+    const app = express();
+    app.use(express.json());
+
+    const history = new HistoryService();
+    const fn = jest.fn();
+    history.record(fn);
+
+    const server = new Server(history);
+    server.run(app, {} as any, {} as any);
+
+    const result = await new Promise<{ status: number; body: any }>((resolve) => {
+      const srv = http.createServer(app);
+      srv.listen(() => {
+        const { port } = srv.address() as any;
+        const req = http.request(
+          {
+            method: 'POST',
+            port,
+            path: '/undo',
+            headers: { 'Content-Type': 'application/json' },
+          },
+          (res) => {
+            let data = '';
+            res.on('data', (c) => { data += c; });
+            res.on('end', () => {
+              resolve({ status: res.statusCode || 0, body: JSON.parse(data || '{}') });
+              srv.close();
+            });
+          },
+        );
+        req.end('{}');
+      });
+    });
+
+    expect(result.status).toBe(200);
+    expect(fn).toHaveBeenCalled();
+  });
+});
+

--- a/tests/services/History.test.ts
+++ b/tests/services/History.test.ts
@@ -1,0 +1,31 @@
+import { HistoryService } from '../../src/services/history';
+
+describe('HistoryService', () => {
+  it('records operations and undoes them in reverse order', async () => {
+    const history = new HistoryService();
+    const order: number[] = [];
+
+    history.record(async () => { order.push(1); });
+    history.record(async () => { order.push(2); });
+
+    await history.undo();
+    expect(order).toEqual([2]);
+
+    await history.undo();
+    expect(order).toEqual([2, 1]);
+  });
+
+  it('supports multi-step undo', async () => {
+    const history = new HistoryService();
+    const calls: number[] = [];
+
+    history.record(() => { calls.push(1); });
+    history.record(() => { calls.push(2); });
+    history.record(() => { calls.push(3); });
+
+    await history.undo(2);
+    expect(calls).toEqual([3, 2]);
+    expect(history.length).toBe(1);
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "strict": true,
+    "jsx": "preserve",
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- implement HistoryService to record reversible operations and support multi-step undo
- create UndoToast UI component that times out automatically
- expose /undo server endpoint for rolling back operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e804fa308328adbb3a1c275f6d25