### PR TITLE
feat: add kv cache and rate limiter

### DIFF
--- a/src/api/admin/cacheMetrics.ts
+++ b/src/api/admin/cacheMetrics.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from 'express';
+import kvCache from '../../lib/cache/kvCache';
+import { rateLimiter } from '../../middleware/rateLimit';
+
+export default function cacheMetrics(req: Request, res: Response): void {
+  res.json({
+    cache: kvCache.status(),
+    limiter: rateLimiter.status(),
+  });
+}

--- a/src/lib/cache/kvCache.ts
+++ b/src/lib/cache/kvCache.ts
@@ -1,0 +1,72 @@
+export interface CacheEntry<T> {
+  value: T;
+  expires: number;
+}
+
+export class KVCache {
+  private store = new Map<string, CacheEntry<unknown>>();
+
+  private hits = 0;
+
+  private misses = 0;
+
+  private buildKey(endpoint: string, params: Record<string, unknown>): string {
+    const sortedKeys = Object.keys(params).sort();
+    const paramString = sortedKeys
+      .map((k) => `${k}:${JSON.stringify(params[k])}`)
+      .join('|');
+    return `${endpoint}|${paramString}`;
+  }
+
+  get<T>(endpoint: string, params: Record<string, unknown>): T | undefined {
+    const key = this.buildKey(endpoint, params);
+    const entry = this.store.get(key);
+    if (!entry) {
+      this.misses += 1;
+      return undefined;
+    }
+    if (entry.expires < Date.now()) {
+      this.store.delete(key);
+      this.misses += 1;
+      return undefined;
+    }
+    this.hits += 1;
+    return entry.value as T;
+  }
+
+  set<T>(endpoint: string, params: Record<string, unknown>, value: T, ttl: number): void {
+    const key = this.buildKey(endpoint, params);
+    this.store.set(key, { value, expires: Date.now() + ttl });
+  }
+
+  async getOrSet<T>(
+    endpoint: string,
+    params: Record<string, unknown>,
+    loader: () => Promise<T> | T,
+    ttl: number,
+  ): Promise<T> {
+    const cached = this.get<T>(endpoint, params);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const value = await loader();
+    this.set(endpoint, params, value, ttl);
+    return value;
+  }
+
+  hitRate(): number {
+    const total = this.hits + this.misses;
+    return total === 0 ? 0 : this.hits / total;
+  }
+
+  status(): { hits: number; misses: number; hitRate: number } {
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: this.hitRate(),
+    };
+  }
+}
+
+const kvCache = new KVCache();
+export default kvCache;

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import kvCache from '../lib/cache/kvCache';
+
+interface Bucket {
+  tokens: number;
+  last: number;
+}
+
+class RateLimiter {
+  private active = new Set<string>();
+
+  constructor(private limit = 5, private windowMs = 60 * 1000) {}
+
+  consume(key: string): { allowed: boolean; retryAfter?: number; tokensLeft?: number } {
+    const now = Date.now();
+    let bucket = kvCache.get<Bucket>('rl', { key });
+    if (!bucket) {
+      bucket = { tokens: this.limit, last: now };
+    } else {
+      const elapsed = now - bucket.last;
+      const refill = Math.floor((elapsed / this.windowMs) * this.limit);
+      if (refill > 0) {
+        bucket.tokens = Math.min(this.limit, bucket.tokens + refill);
+        bucket.last = now;
+      }
+    }
+
+    this.active.add(key);
+
+    if (bucket.tokens > 0) {
+      bucket.tokens -= 1;
+      kvCache.set('rl', { key }, bucket, this.windowMs);
+      return { allowed: true, tokensLeft: bucket.tokens };
+    }
+    const retryAfter = this.windowMs - (now - bucket.last);
+    kvCache.set('rl', { key }, bucket, this.windowMs);
+    return { allowed: false, retryAfter };
+  }
+
+  status(): { limit: number; windowMs: number; active: number } {
+    return { limit: this.limit, windowMs: this.windowMs, active: this.active.size };
+  }
+}
+
+export const rateLimiter = new RateLimiter();
+
+export default function rateLimit(req: Request, res: Response, next: NextFunction): void {
+  const session = (req.headers['session'] as string) || '';
+  const key = `${req.ip}:${session}`;
+  const result = rateLimiter.consume(key);
+  if (result.allowed) {
+    return next();
+  }
+  res.set('Retry-After', Math.ceil((result.retryAfter || 0) / 1000).toString());
+  res.status(429).send('Too Many Requests');
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,13 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import rateLimit from '../../middleware/rateLimit';
+import cacheMetrics from '../../api/admin/cacheMetrics';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.use(rateLimit);
+    app.get('/api/admin/cache-metrics', cacheMetrics);
   }
 }

--- a/tests/middleware/rateLimit.test.ts
+++ b/tests/middleware/rateLimit.test.ts
@@ -1,0 +1,63 @@
+import 'reflect-metadata';
+import http from 'http';
+import express from 'express';
+import kvCache from '../../src/lib/cache/kvCache';
+import rateLimit from '../../src/middleware/rateLimit';
+import cacheMetrics from '../../src/api/admin/cacheMetrics';
+
+describe('rate limiter and cache', () => {
+  it('speeds up cached requests and blocks abusive traffic', async () => {
+    const app = express();
+    app.use(rateLimit);
+
+    app.get('/slow', async (req, res) => {
+      const data = await kvCache.getOrSet('/slow', {}, async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        return { ok: true };
+      }, 1000);
+      res.json(data);
+    });
+
+    app.get('/api/admin/cache-metrics', cacheMetrics);
+
+    const server = app.listen(0);
+    const { port } = server.address() as any;
+
+    const request = (
+      path: string,
+      headers: Record<string, string> = {},
+    ) => new Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }>((resolve) => {
+      const opts = { port, path, headers };
+      const req = http.get(opts, (resp) => {
+        let body = '';
+        resp.on('data', (d) => { body += d; });
+        resp.on('end', () => resolve({ status: resp.statusCode || 0, headers: resp.headers, body }));
+      });
+      req.end();
+    });
+
+    const t1Start = Date.now();
+    await request('/slow');
+    const t1 = Date.now() - t1Start;
+
+    const t2Start = Date.now();
+    await request('/slow');
+    const t2 = Date.now() - t2Start;
+
+    expect(t2).toBeLessThan(t1);
+
+    for (let i = 0; i < 3; i += 1) {
+      await request('/slow');
+    }
+    const over = await request('/slow');
+    expect(over.status).toBe(429);
+    expect(over.headers['retry-after']).toBeDefined();
+
+    const metricsResp = await request('/api/admin/cache-metrics', { session: 'admin' });
+    const metrics = JSON.parse(metricsResp.body);
+    expect(metrics.cache.hitRate).toBeGreaterThan(0);
+    expect(metrics.limiter.limit).toBeDefined();
+
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic KV cache with TTL and metrics reporting
- implement token bucket rate limiter middleware
- expose /api/admin/cache-metrics for cache hit rate and limiter status
- test caching speed, limiter 429 with Retry-After, and metrics route

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eedd30e0832885a1c9eb38906167