### PR TITLE
Add content moderation and secure links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,35 @@
+interface LinkProps {
+  href: string;
+  children?: any;
+  [key: string]: any;
+}
+
+const ALLOWLIST = ['github.com', 'linkedin.com'];
+
+export function isAllowedUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return ALLOWLIST.some((d) => hostname === d || hostname.endsWith(`.${d}`));
+  } catch {
+    return false;
+  }
+}
+
+export default function Link({ href, children, ...rest }: LinkProps): any {
+  if (!isAllowedUrl(href)) {
+    return null;
+  }
+
+  return {
+    type: 'a',
+    props: {
+      href,
+      rel: 'noopener noreferrer',
+      target: '_blank',
+      ...rest,
+      children,
+    },
+  };
+}
+
+export { ALLOWLIST };

--- a/src/middleware/contentFilter.ts
+++ b/src/middleware/contentFilter.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from 'express';
+
+// Simple profanity list for demonstration purposes
+const PROFANITY_LIST = ['damn', 'hell', 'shit'];
+
+const URL_REGEX = /https?:\/\/[^\s]+/i;
+
+export default function contentFilter(req: Request, res: Response, next: NextFunction): void {
+  const text = typeof req.body?.text === 'string' ? req.body.text : undefined;
+
+  if (text) {
+    if (PROFANITY_LIST.some((w) => new RegExp(`\\b${w}\\b`, 'i').test(text))) {
+      res.status(400).json({ error: 'Profanity is not allowed' });
+      return;
+    }
+
+    if (URL_REGEX.test(text)) {
+      res.status(400).json({ error: 'Links are not allowed' });
+      return;
+    }
+  }
+
+  next();
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,14 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import type { Application } from 'express';
+import contentFilter from '../../middleware/contentFilter';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    // Apply content filter middleware to all requests before routes
+    app.use(contentFilter);
+
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/pages/admin/moderation.tsx
+++ b/src/pages/admin/moderation.tsx
@@ -1,0 +1,18 @@
+// Simple admin moderation page placeholder
+// This file is not executed in tests but documents how moderators can manage the queue
+
+interface ModerationItem {
+  id: string;
+  text: string;
+}
+
+export default function ModerationPage(): any {
+  // Pseudo-implementation to avoid React dependency
+  // In a real application this would use React hooks and components
+  return {
+    type: 'div',
+    props: {
+      children: 'Moderation panel placeholder',
+    },
+  };
+}

--- a/src/pages/api/moderation/queue.ts
+++ b/src/pages/api/moderation/queue.ts
@@ -1,0 +1,48 @@
+interface QueueItem {
+  id: string;
+  text: string;
+}
+
+let queue: QueueItem[] = [];
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+export default async function handler(req: any, res: any): Promise<void> {
+  const { method } = req;
+
+  if (method === 'GET') {
+    res.status(200).json(queue);
+    return;
+  }
+
+  if (method === 'POST') {
+    const { text } = req.body || {};
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      res.status(400).json({ error: 'Missing text' });
+      return;
+    }
+    const item = { id: generateId(), text };
+    queue.push(item);
+    res.status(201).json(item);
+    return;
+  }
+
+  if (method === 'PUT') {
+    const { id, action } = req.body || {};
+    if (!id) {
+      res.status(400).json({ error: 'Missing id' });
+      return;
+    }
+    queue = queue.filter((item) => item.id !== id);
+    res.status(200).json({ id, action });
+    return;
+  }
+
+  res.status(405).end();
+}
+
+export function _clearQueue(): void {
+  queue = [];
+}

--- a/tests/api/moderation.test.ts
+++ b/tests/api/moderation.test.ts
@@ -1,0 +1,43 @@
+import handler, { _clearQueue } from '../../src/pages/api/moderation/queue';
+
+describe('moderation queue API', () => {
+  function createRes() {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    res.setHeader = jest.fn();
+    res.end = jest.fn();
+    return res;
+  }
+
+  beforeEach(() => {
+    _clearQueue();
+  });
+
+  it('adds and resolves items', async () => {
+    // Add item
+    let req: any = { method: 'POST', body: { text: 'needs review' } };
+    let res = createRes();
+    await handler(req, res);
+    const item = res.json.mock.calls[0][0];
+    expect(item.text).toBe('needs review');
+
+    // Check queue
+    req = { method: 'GET' };
+    res = createRes();
+    await handler(req, res);
+    expect(res.json.mock.calls[0][0].length).toBe(1);
+
+    // Approve/remove item
+    req = { method: 'PUT', body: { id: item.id, action: 'approve' } };
+    res = createRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+
+    // Ensure queue is empty
+    req = { method: 'GET' };
+    res = createRes();
+    await handler(req, res);
+    expect(res.json.mock.calls[0][0].length).toBe(0);
+  });
+});

--- a/tests/middleware/contentFilter.test.ts
+++ b/tests/middleware/contentFilter.test.ts
@@ -1,0 +1,36 @@
+import contentFilter from '../../src/middleware/contentFilter';
+
+describe('contentFilter middleware', () => {
+  function createRes() {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  }
+
+  it('blocks profanity', () => {
+    const req: any = { body: { text: 'This is damn text' } };
+    const res = createRes();
+    const next = jest.fn();
+    contentFilter(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('blocks URLs', () => {
+    const req: any = { body: { text: 'Check http://example.com' } };
+    const res = createRes();
+    const next = jest.fn();
+    contentFilter(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows clean text', () => {
+    const req: any = { body: { text: 'Hello world' } };
+    const res = createRes();
+    const next = jest.fn();
+    contentFilter(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add profanity and URL blocking middleware
- enforce allowlist on custom Link component
- implement moderation queue API with admin placeholder page
- test content filter and moderation workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eede58548328bc576050becbe6d7