### PR TITLE
feat: add capability detection and telemetry

### DIFF
--- a/src/components/adaptiveProfile.ts
+++ b/src/components/adaptiveProfile.ts
@@ -1,0 +1,21 @@
+import CapabilitiesDetector from '../lib/capabilities';
+import Telemetry from '../lib/telemetry';
+
+export type ProfileVariant = 'simplified' | 'advanced';
+
+export default class AdaptiveProfile {
+  static resolve(): ProfileVariant {
+    const capabilities = CapabilitiesDetector.detect();
+    Telemetry.sendCapabilities(capabilities);
+
+    const isLow = !(
+      capabilities.webgl &&
+      capabilities.wasm &&
+      capabilities.clipboard &&
+      capabilities.notifications &&
+      capabilities.pointer === 'fine'
+    );
+
+    return isLow ? 'simplified' : 'advanced';
+  }
+}

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -1,0 +1,55 @@
+export interface Capabilities {
+  webgl: boolean;
+  wasm: boolean;
+  clipboard: boolean;
+  notifications: boolean;
+  pointer: string;
+}
+
+export default class CapabilitiesDetector {
+  static detect(): Capabilities {
+    return {
+      webgl: CapabilitiesDetector.hasWebGL(),
+      wasm: CapabilitiesDetector.hasWasm(),
+      clipboard: CapabilitiesDetector.hasClipboard(),
+      notifications: CapabilitiesDetector.hasNotifications(),
+      pointer: CapabilitiesDetector.pointerType(),
+    };
+  }
+
+  static hasWebGL(): boolean {
+    try {
+      const canvas = document.createElement('canvas');
+      return !!(
+        canvas.getContext &&
+        (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  static hasWasm(): boolean {
+    return typeof WebAssembly === 'object';
+  }
+
+  static hasClipboard(): boolean {
+    return !!navigator.clipboard;
+  }
+
+  static hasNotifications(): boolean {
+    return 'Notification' in window;
+  }
+
+  static pointerType(): string {
+    if (window.matchMedia('(pointer: coarse)').matches) {
+      return 'coarse';
+    }
+
+    if (window.matchMedia('(pointer: fine)').matches) {
+      return 'fine';
+    }
+
+    return 'none';
+  }
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,26 @@
+import { Capabilities } from './capabilities';
+
+const TELEMETRY_ENDPOINT = '/telemetry';
+
+export default class Telemetry {
+  static sendCapabilities(capabilities: Capabilities): void {
+    try {
+      const payload = JSON.stringify({ capabilities });
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(TELEMETRY_ENDPOINT, payload);
+        return;
+      }
+
+      fetch(TELEMETRY_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        keepalive: true,
+      }).catch(() => {
+        // ignore errors
+      });
+    } catch (e) {
+      // ignore errors
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- detect browser capabilities (WebGL, WebAssembly, clipboard, notifications, pointer)
- adapt profile component based on detected capabilities
- send capability telemetry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3eedeb0f88328926cce72b7fd5367