### PR TITLE
feat: add extensible context menu component

### DIFF
--- a/src/components/contextMenu/Menu.tsx
+++ b/src/components/contextMenu/Menu.tsx
@@ -1,0 +1,88 @@
+import { saveFocus, restoreFocus } from './focus';
+
+export interface MenuAction {
+  label: string;
+  handler: () => void;
+}
+
+const globalActions: MenuAction[] = [];
+
+export function registerMenuAction(action: MenuAction) {
+  globalActions.push(action);
+}
+
+export function clearMenuActions() {
+  globalActions.length = 0;
+}
+
+export default class Menu {
+  private opener: HTMLElement;
+  private actions: MenuAction[];
+  private menuEl: HTMLUListElement;
+  private longPressTimer: number | null = null;
+
+  constructor(opener: HTMLElement, actions: MenuAction[] = []) {
+    this.opener = opener;
+    this.actions = actions;
+    this.menuEl = document.createElement('ul');
+    this.menuEl.tabIndex = -1;
+
+    opener.addEventListener('contextmenu', this.onContextMenu);
+    opener.addEventListener('keydown', this.onKeyDown);
+    opener.addEventListener('touchstart', this.onTouchStart);
+    opener.addEventListener('touchend', this.onTouchEnd);
+  }
+
+  private render() {
+    this.menuEl.innerHTML = '';
+    const acts = [...globalActions, ...this.actions];
+    acts.forEach((action) => {
+      const li = document.createElement('li');
+      li.textContent = action.label;
+      li.addEventListener('click', () => {
+        action.handler();
+        this.close();
+      });
+      this.menuEl.appendChild(li);
+    });
+  }
+
+  private onContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    this.open();
+  };
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+      e.preventDefault();
+      this.open();
+    }
+  };
+
+  private onTouchStart = () => {
+    this.longPressTimer = window.setTimeout(() => {
+      this.open();
+    }, 500);
+  };
+
+  private onTouchEnd = () => {
+    if (this.longPressTimer !== null) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
+  };
+
+  open() {
+    this.render();
+    saveFocus(this.opener);
+    document.body.appendChild(this.menuEl);
+    this.menuEl.focus();
+  }
+
+  close() {
+    if (this.menuEl.parentElement) {
+      this.menuEl.parentElement.removeChild(this.menuEl);
+      restoreFocus();
+    }
+  }
+}

--- a/src/components/contextMenu/focus.ts
+++ b/src/components/contextMenu/focus.ts
@@ -1,0 +1,14 @@
+let lastFocused: HTMLElement | null = null;
+
+export function saveFocus(el: HTMLElement) {
+  lastFocused = el;
+}
+
+export function restoreFocus() {
+  if (lastFocused) {
+    lastFocused.focus();
+    lastFocused = null;
+  }
+}
+
+export default { saveFocus, restoreFocus };

--- a/tests/components/contextMenu/Menu.test.ts
+++ b/tests/components/contextMenu/Menu.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Menu, { registerMenuAction, clearMenuActions } from '../../../src/components/contextMenu/Menu';
+
+describe('ContextMenu', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    clearMenuActions();
+  });
+
+  test('opens on right click and executes action', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const handler = jest.fn();
+    registerMenuAction({ label: 'Action', handler });
+
+    // eslint-disable-next-line no-new
+    new Menu(opener);
+
+    opener.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
+
+    const item = document.querySelector('li') as HTMLLIElement;
+    expect(item).not.toBeNull();
+
+    item.click();
+    expect(handler).toHaveBeenCalled();
+    expect(document.activeElement).toBe(opener);
+  });
+
+  test('opens on long press and executes action', () => {
+    jest.useFakeTimers();
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const handler = jest.fn();
+    registerMenuAction({ label: 'Action', handler });
+    // eslint-disable-next-line no-new
+    new Menu(opener);
+
+    opener.dispatchEvent(new Event('touchstart', { bubbles: true }));
+    jest.advanceTimersByTime(600);
+
+    const item = document.querySelector('li') as HTMLLIElement;
+    expect(item).not.toBeNull();
+
+    item.click();
+    expect(handler).toHaveBeenCalled();
+    expect(document.activeElement).toBe(opener);
+    jest.useRealTimers();
+  });
+
+  test('opens on keyboard invocation and executes action', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const handler = jest.fn();
+    registerMenuAction({ label: 'Action', handler });
+    // eslint-disable-next-line no-new
+    new Menu(opener);
+
+    opener.dispatchEvent(new KeyboardEvent('keydown', { key: 'ContextMenu', bubbles: true }));
+
+    const item = document.querySelector('li') as HTMLLIElement;
+    expect(item).not.toBeNull();
+
+    item.click();
+    expect(handler).toHaveBeenCalled();
+    expect(document.activeElement).toBe(opener);
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "strict": true,
+    "jsx": "preserve",
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- add composable context menu with mouse, touch, and keyboard triggers
- ensure focus returns to opener on close
- test custom action registration across input types

## Testing
- `yarn test`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn install` *(fails: node-sass couldn't be built)*

------
https://chatgpt.com/codex/tasks/task_e_68b3eedff3348328a557b898861cfb05