### PR TITLE
feat: add popout launcher with persistent window bounds

### DIFF
--- a/src/lib/windows/popout.ts
+++ b/src/lib/windows/popout.ts
@@ -1,0 +1,145 @@
+import { loadBounds, saveBounds, WindowBounds } from './storage';
+
+export interface PopoutOptions<T = unknown> {
+  /** url to open */
+  url: string;
+  /** type of popout window used for storage */
+  type: string;
+  /** optional name of window */
+  name?: string;
+  /** initial data to synchronise with popout */
+  initialData?: T;
+  /** callback for incoming messages */
+  onMessage?: (data: any) => void;
+  /** called when popout cannot be opened */
+  onFallback?: () => void;
+}
+
+export interface PopoutHandle<T = unknown> {
+  /** reference to created window */
+  win: Window;
+  /** send message to popout */
+  send: (data: T) => void;
+  /** close the popout */
+  close: () => void;
+}
+
+function buildFeatures(bounds?: WindowBounds): string {
+  const features: Record<string, number | string> = {
+    left: bounds?.left ?? 100,
+    top: bounds?.top ?? 100,
+    width: bounds?.width ?? 800,
+    height: bounds?.height ?? 600,
+  };
+  return Object.entries(features)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(',');
+}
+
+/**
+ * Open a popout window and synchronise state with it using postMessage.
+ * Falls back to in-page window when popouts are blocked.
+ */
+export function openPopout<T = unknown>(options: PopoutOptions<T>): PopoutHandle<T> | null {
+  const bounds = loadBounds(options.type);
+  const win = window.open(options.url, options.name ?? options.type, buildFeatures(bounds));
+
+  if (!win) {
+    options.onFallback?.();
+    return null;
+  }
+
+  // detect blocked popouts that close immediately
+  if (win.closed) {
+    options.onFallback?.();
+    return null;
+  }
+
+  // sync incoming messages
+  const messageHandler = (event: MessageEvent) => {
+    if (event.source === win) {
+      options.onMessage?.(event.data);
+    }
+  };
+  window.addEventListener('message', messageHandler);
+
+  // helper to send messages to popout
+  const send = (data: T): void => {
+    if (!win.closed) {
+      win.postMessage(data, '*');
+    }
+  };
+
+  // send initial state when popout loads
+  if (options.initialData !== undefined) {
+    const onLoad = () => {
+      send(options.initialData as T);
+      win.removeEventListener('load', onLoad);
+    };
+    win.addEventListener('load', onLoad);
+  }
+
+  // remember window position and size
+  const remember = () => {
+    try {
+      saveBounds(options.type, {
+        left: win.screenX,
+        top: win.screenY,
+        width: win.outerWidth,
+        height: win.outerHeight,
+      });
+    } catch {
+      // ignore
+    }
+  };
+  win.addEventListener('beforeunload', remember);
+
+  // watcher to react when window is closed
+  const closeWatcher = window.setInterval(() => {
+    if (win.closed) {
+      window.clearInterval(closeWatcher);
+      window.removeEventListener('message', messageHandler);
+      options.onFallback?.();
+    }
+  }, 500);
+
+  const close = () => {
+    window.clearInterval(closeWatcher);
+    window.removeEventListener('message', messageHandler);
+    remember();
+    win.close();
+  };
+
+  return { win, send, close };
+}
+
+/**
+ * Connect a popout window back to its opener. Used inside the popout window
+ * to keep it in sync with the main page.
+ */
+export function connectToOpener<T = unknown>(onMessage: (data: T) => void) {
+  const opener = window.opener;
+  if (!opener) {
+    return {
+      send: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  const handler = (event: MessageEvent) => {
+    if (event.source === opener) {
+      onMessage(event.data as T);
+    }
+  };
+  window.addEventListener('message', handler);
+
+  const send = (data: T): void => {
+    opener.postMessage(data, '*');
+  };
+
+  const dispose = () => {
+    window.removeEventListener('message', handler);
+  };
+
+  return { send, dispose };
+}

--- a/src/lib/windows/storage.ts
+++ b/src/lib/windows/storage.ts
@@ -1,0 +1,31 @@
+export interface WindowBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+const KEY_PREFIX = 'gportfolio:popout:';
+
+function getKey(type: string): string {
+  return `${KEY_PREFIX}${type}`;
+}
+
+export function saveBounds(type: string, bounds: WindowBounds): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(getKey(type), JSON.stringify(bounds));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function loadBounds(type: string): WindowBounds | undefined {
+  try {
+    if (typeof localStorage === 'undefined') return undefined;
+    const raw = localStorage.getItem(getKey(type));
+    return raw ? JSON.parse(raw) as WindowBounds : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add storage utilities to persist popout window bounds
- implement popout launcher with postMessage syncing and fallback logic

## Testing
- `npx tsc -p tsconfig.json` *(fails: Generic type 'SyncWaterfallHook<T, AdditionalOptions>' requires between 1 and 2 type arguments)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3eee15ae0832890db9bfaba017717