### PR TITLE
feat: secure file previewers with streaming support

### DIFF
--- a/src/lib/previewSecurity.ts
+++ b/src/lib/previewSecurity.ts
@@ -1,0 +1,33 @@
+const DANGEROUS_MIME_TYPES: string[] = [
+  'application/javascript',
+  'text/javascript',
+  'application/ecmascript',
+  'text/ecmascript',
+  'application/x-msdownload',
+  'application/x-msdos-program',
+  'application/x-msdos-windows',
+  'application/x-ms-dos-executable',
+  'application/x-executable',
+  'application/x-sh',
+  'application/x-csh',
+  'application/x-python',
+];
+
+/**
+ * Checks whether the given MIME type is considered safe for previewing.
+ */
+export function isSafeMimeType(mime: string): boolean {
+  return !DANGEROUS_MIME_TYPES.includes(mime);
+}
+
+/**
+ * Returns a human readable message indicating the preview was blocked.
+ */
+export function blockedMessage(mime: string): string {
+  return `Preview for ${mime} is blocked for security reasons.`;
+}
+
+export default {
+  isSafeMimeType,
+  blockedMessage,
+};

--- a/src/lib/previewers/image.ts
+++ b/src/lib/previewers/image.ts
@@ -1,0 +1,11 @@
+import { Previewer } from './index';
+
+/**
+ * Generates an object URL that can be used as the src attribute for an image
+ * element.
+ */
+export const imagePreviewer: Previewer = async (blob: Blob): Promise<string> => {
+  return URL.createObjectURL(blob);
+};
+
+export default imagePreviewer;

--- a/src/lib/previewers/index.ts
+++ b/src/lib/previewers/index.ts
@@ -1,0 +1,38 @@
+import imagePreviewer from './image';
+import videoPreviewer from './video';
+import textPreviewer from './text';
+import jsonPreviewer from './json';
+import { isSafeMimeType, blockedMessage } from '../previewSecurity';
+
+export type Previewer = (
+  blob: Blob,
+  onChunk?: (text: string) => void,
+) => Promise<any>;
+
+interface PreviewerEntry {
+  test: RegExp;
+  handler: Previewer;
+}
+
+const previewers: PreviewerEntry[] = [
+  { test: /^image\//, handler: imagePreviewer },
+  { test: /^video\//, handler: videoPreviewer },
+  { test: /^text\//, handler: textPreviewer },
+  { test: /^(application|text)\/json$/, handler: jsonPreviewer },
+];
+
+/**
+ * Returns an appropriate previewer for the given MIME type.
+ * If the MIME type is considered unsafe, a previewer returning a safe message
+ * is returned instead.
+ */
+export function getPreviewer(mime: string): Previewer | null {
+  if (!isSafeMimeType(mime)) {
+    return async () => blockedMessage(mime);
+  }
+
+  const entry = previewers.find((p) => p.test.test(mime));
+  return entry ? entry.handler : null;
+}
+
+export { imagePreviewer, videoPreviewer, textPreviewer, jsonPreviewer };

--- a/src/lib/previewers/json.ts
+++ b/src/lib/previewers/json.ts
@@ -1,0 +1,12 @@
+import { Previewer } from './index';
+
+/**
+ * Reads a JSON blob and returns a formatted string representation.
+ */
+export const jsonPreviewer: Previewer = async (blob: Blob): Promise<string> => {
+  const text = await blob.text();
+  const data = JSON.parse(text);
+  return JSON.stringify(data, null, 2);
+};
+
+export default jsonPreviewer;

--- a/src/lib/previewers/text.ts
+++ b/src/lib/previewers/text.ts
@@ -1,0 +1,37 @@
+import { Previewer } from './index';
+
+/**
+ * Streams a text readable stream and emits decoded chunks through the
+ * provided callback.
+ */
+export async function streamText(
+  stream: ReadableStream<Uint8Array>,
+  onChunk: (text: string) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    onChunk(decoder.decode(value, { stream: true }));
+  }
+
+  const remainder = decoder.decode();
+  if (remainder) {
+    onChunk(remainder);
+  }
+}
+
+/**
+ * Reads a text blob and streams its contents chunk by chunk.
+ */
+export const textPreviewer: Previewer = async (
+  blob: Blob,
+  onChunk?: (text: string) => void,
+): Promise<void> => {
+  const callback = onChunk || (() => {});
+  await streamText(blob.stream(), callback);
+};
+
+export default textPreviewer;

--- a/src/lib/previewers/video.ts
+++ b/src/lib/previewers/video.ts
@@ -1,0 +1,11 @@
+import { Previewer } from './index';
+
+/**
+ * Generates an object URL that can be used as the src attribute for a video
+ * element.
+ */
+export const videoPreviewer: Previewer = async (blob: Blob): Promise<string> => {
+  return URL.createObjectURL(blob);
+};
+
+export default videoPreviewer;

--- a/tests/lib/previewers.test.ts
+++ b/tests/lib/previewers.test.ts
@@ -1,0 +1,98 @@
+import { getPreviewer } from '../../src/lib/previewers';
+import { streamText } from '../../src/lib/previewers/text';
+import { isSafeMimeType } from '../../src/lib/previewSecurity';
+
+const encoder = new TextEncoder();
+
+class SimpleReadableStream {
+  private chunks: Uint8Array[];
+
+  constructor(chunks: Uint8Array[]) {
+    this.chunks = chunks;
+  }
+
+  getReader() {
+    let index = 0;
+    return {
+      read: async () => {
+        if (index < this.chunks.length) {
+          const value = this.chunks[index];
+          index += 1;
+          return { value, done: false };
+        }
+        return { value: undefined, done: true };
+      },
+    };
+  }
+}
+
+function makeBlob(content: string): Blob {
+  const chunk = encoder.encode(content);
+  return {
+    text: async () => content,
+    stream: () => new SimpleReadableStream([chunk]),
+  } as unknown as Blob;
+}
+
+function makeChunkedBlob(chunks: string[]): Blob {
+  const encoded = chunks.map((c) => encoder.encode(c));
+  return {
+    text: async () => chunks.join(''),
+    stream: () => new SimpleReadableStream(encoded),
+  } as unknown as Blob;
+}
+
+(global as any).URL = {
+  createObjectURL: () => 'blob:mock',
+};
+
+describe('Previewers', () => {
+  it('streams text in chunks', async () => {
+    const stream = new SimpleReadableStream([
+      encoder.encode('hello '),
+      encoder.encode('world'),
+    ]) as unknown as ReadableStream<Uint8Array>;
+
+    const chunks: string[] = [];
+    await streamText(stream, (chunk) => chunks.push(chunk));
+    expect(chunks).toStrictEqual(['hello ', 'world']);
+  });
+
+  it('previews images', async () => {
+    const previewer = getPreviewer('image/png');
+    expect(previewer).not.toBeNull();
+    const url = await previewer!(makeBlob(''));
+    expect(typeof url).toBe('string');
+    expect(url.startsWith('blob:')).toBe(true);
+  });
+
+  it('previews json', async () => {
+    const previewer = getPreviewer('application/json');
+    expect(previewer).not.toBeNull();
+    const blob = makeBlob('{"a":1}');
+    const text = await previewer!(blob);
+    const expected = `{
+  "a": 1
+}`;
+    expect(text).toBe(expected);
+  });
+
+  it('previews text using chunks', async () => {
+    const previewer = getPreviewer('text/plain');
+    expect(previewer).not.toBeNull();
+    const blob = makeChunkedBlob(['chunked ', 'text']);
+    const chunks: string[] = [];
+    await previewer!(blob, (chunk) => chunks.push(chunk));
+    expect(chunks.join('')).toBe('chunked text');
+  });
+
+  it('blocks unsafe types', async () => {
+    expect(isSafeMimeType('application/javascript')).toBe(false);
+    const previewer = getPreviewer('application/javascript');
+    expect(previewer).not.toBeNull();
+    const onChunk = jest.fn();
+    const message = await previewer!(makeBlob('console.log(1)'), onChunk);
+    expect(message).toMatch(/blocked/);
+    expect(onChunk).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add image, video, text, and JSON previewers with central selector
- stream large text files in chunks for responsive rendering
- block dangerous MIME types with a security guard
- test previewing behavior and safety checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3eee561a48328abb6cbc4d1d81045