### PR TITLE
Add route skeletons with delayed shimmer

### DIFF
--- a/src/components/skeletons/_base.scss
+++ b/src/components/skeletons/_base.scss
@@ -1,0 +1,29 @@
+.skeleton {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.5), transparent);
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}

--- a/src/components/skeletons/config/index.scss
+++ b/src/components/skeletons/config/index.scss
@@ -1,0 +1,26 @@
+@import '../_base';
+
+.config-skeleton {
+  padding: 16px;
+}
+
+.skeleton-block {
+  margin-bottom: 16px;
+}
+
+.skeleton-label {
+  width: 120px;
+  height: 20px;
+  margin-bottom: 8px;
+}
+
+.skeleton-input {
+  width: 100%;
+  height: 40px;
+  margin-bottom: 8px;
+}
+
+.skeleton-desc {
+  width: 80%;
+  height: 16px;
+}

--- a/src/components/skeletons/config/index.ts
+++ b/src/components/skeletons/config/index.ts
@@ -1,0 +1,19 @@
+import './index.scss';
+
+export default function createConfigSkeleton(): HTMLElement {
+  const skeleton = document.createElement('section');
+  skeleton.className = 'config-skeleton';
+  skeleton.innerHTML = `
+    <div class="skeleton-block">
+      <div class="skeleton-label skeleton"></div>
+      <div class="skeleton-input skeleton"></div>
+      <div class="skeleton-desc skeleton"></div>
+    </div>
+    <div class="skeleton-block">
+      <div class="skeleton-label skeleton"></div>
+      <div class="skeleton-input skeleton"></div>
+      <div class="skeleton-desc skeleton"></div>
+    </div>
+  `;
+  return skeleton;
+}

--- a/src/components/skeletons/default/index.scss
+++ b/src/components/skeletons/default/index.scss
@@ -1,0 +1,40 @@
+@import '../_base';
+
+.default-skeleton {
+  padding: 16px;
+}
+
+.default-skeleton__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin-bottom: 16px;
+}
+
+.name {
+  width: 60%;
+  height: 24px;
+  margin-bottom: 8px;
+}
+
+.position {
+  width: 40%;
+  height: 18px;
+}
+
+.default-skeleton__repositories {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.repo {
+  height: 120px;
+}

--- a/src/components/skeletons/default/index.ts
+++ b/src/components/skeletons/default/index.ts
@@ -1,0 +1,18 @@
+import './index.scss';
+
+export default function createDefaultSkeleton(): HTMLElement {
+  const skeleton = document.createElement('div');
+  skeleton.className = 'default-skeleton';
+  const repos = Array.from({ length: 6 }, () => '<div class="repo skeleton"></div>').join('');
+  skeleton.innerHTML = `
+    <header class="default-skeleton__header">
+      <div class="avatar skeleton"></div>
+      <div class="name skeleton"></div>
+      <div class="position skeleton"></div>
+    </header>
+    <main class="default-skeleton__repositories">
+      ${repos}
+    </main>
+  `;
+  return skeleton;
+}

--- a/src/lib/cls.ts
+++ b/src/lib/cls.ts
@@ -1,0 +1,18 @@
+export default function measureCLS(callback: (cls: number) => void): void {
+  let clsValue = 0;
+  const observer = new PerformanceObserver((list) => {
+    list.getEntries().forEach((entry) => {
+      const shift = entry as LayoutShift;
+      if (!shift.hadRecentInput) {
+        clsValue += shift.value;
+      }
+    });
+  });
+  observer.observe({ type: 'layout-shift', buffered: true });
+  window.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      observer.disconnect();
+      callback(clsValue);
+    }
+  });
+}

--- a/src/lib/skeletonDelay.ts
+++ b/src/lib/skeletonDelay.ts
@@ -1,0 +1,4 @@
+export default function skeletonDelay(show: () => void, delay = 200): () => void {
+  const timer = window.setTimeout(show, delay);
+  return () => window.clearTimeout(timer);
+}

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,23 @@
+import createConfigSkeleton from '../../components/skeletons/config';
+import skeletonDelay from '../../lib/skeletonDelay';
+import measureCLS from '../../lib/cls';
+
 (() => {
-  console.log('dev');
+  const skeleton = createConfigSkeleton();
+  skeleton.style.display = 'none';
+  document.body.prepend(skeleton);
+
+  const cancel = skeletonDelay(() => {
+    skeleton.style.display = '';
+  }, 300);
+
+  window.addEventListener('load', () => {
+    cancel();
+    skeleton.remove();
+    console.log('dev');
+  });
+
+  measureCLS((cls) => {
+    console.log('CLS:', cls);
+  });
 })();

--- a/src/templates/default/index.ts
+++ b/src/templates/default/index.ts
@@ -1,1 +1,21 @@
 import '../_common/scripts';
+import createDefaultSkeleton from '../../components/skeletons/default';
+import skeletonDelay from '../../lib/skeletonDelay';
+import measureCLS from '../../lib/cls';
+
+const skeleton = createDefaultSkeleton();
+skeleton.style.display = 'none';
+document.body.prepend(skeleton);
+
+const cancel = skeletonDelay(() => {
+  skeleton.style.display = '';
+}, 300);
+
+window.addEventListener('load', () => {
+  cancel();
+  skeleton.remove();
+});
+
+measureCLS((cls) => {
+  console.log('CLS:', cls);
+});


### PR DESCRIPTION
## Summary
- add reusable skeleton styles with shimmer respecting prefers-reduced-motion
- create route-specific skeleton components for default and config pages
- delay skeleton visibility and log CLS to evaluate layout stability

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eee62af88328a3e73d59f0374241