### PR TITLE
feat: adapt media quality to network

### DIFF
--- a/src/components/media/Image.tsx
+++ b/src/components/media/Image.tsx
@@ -1,0 +1,19 @@
+import { getNetworkInfo } from '../../lib/networkInfo';
+import { logNetwork } from '../../lib/telemetry';
+
+export interface ImageOptions extends Partial<HTMLImageElement> {
+  src: string;
+  lowQualitySrc?: string;
+}
+
+export function createImage(options: ImageOptions): HTMLImageElement {
+  const { src, lowQualitySrc, ...rest } = options;
+  const info = getNetworkInfo();
+  const isSlow = info.saveData || (typeof info.downlink === 'number' && info.downlink < 1);
+  const img = document.createElement('img');
+  img.src = isSlow && lowQualitySrc ? lowQualitySrc : src;
+  Object.assign(img, rest);
+  logNetwork('image');
+  return img;
+}
+export default createImage;

--- a/src/components/media/Video.tsx
+++ b/src/components/media/Video.tsx
@@ -1,0 +1,19 @@
+import { getNetworkInfo } from '../../lib/networkInfo';
+import { logNetwork } from '../../lib/telemetry';
+
+export interface VideoOptions extends Partial<HTMLVideoElement> {
+  src: string;
+  lowQualitySrc?: string;
+}
+
+export function createVideo(options: VideoOptions): HTMLVideoElement {
+  const { src, lowQualitySrc, ...rest } = options;
+  const info = getNetworkInfo();
+  const isSlow = info.saveData || (typeof info.downlink === 'number' && info.downlink < 1);
+  const video = document.createElement('video');
+  video.src = isSlow && lowQualitySrc ? lowQualitySrc : src;
+  Object.assign(video, rest);
+  logNetwork('video');
+  return video;
+}
+export default createVideo;

--- a/src/lib/networkInfo.ts
+++ b/src/lib/networkInfo.ts
@@ -1,0 +1,35 @@
+export interface NetworkInfo {
+  downlink?: number;
+  rtt?: number;
+  saveData?: boolean;
+}
+
+function getConnection(): any | undefined {
+  if (typeof navigator === 'undefined') {
+    return undefined;
+  }
+
+  const nav = navigator as any;
+  return nav.connection || nav.mozConnection || nav.webkitConnection;
+}
+
+export function getNetworkInfo(): NetworkInfo {
+  const connection = getConnection();
+  if (!connection) {
+    return {};
+  }
+
+  const { downlink, rtt, saveData } = connection;
+  return { downlink, rtt, saveData };
+}
+
+export function onNetworkChange(callback: (info: NetworkInfo) => void): () => void {
+  const connection = getConnection();
+  if (!connection || !connection.addEventListener) {
+    return () => {};
+  }
+
+  const handler = () => callback(getNetworkInfo());
+  connection.addEventListener('change', handler);
+  return () => connection.removeEventListener('change', handler);
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,38 @@
+import { getNetworkInfo, NetworkInfo } from './networkInfo';
+
+export interface TelemetryEvent {
+  event: string;
+  duration?: number;
+  network: NetworkInfo;
+  cause: 'network' | 'compute';
+}
+
+function determineCause(info: NetworkInfo): 'network' | 'compute' {
+  if (info.saveData) {
+    return 'network';
+  }
+  if (typeof info.downlink === 'number' && info.downlink < 1) {
+    return 'network';
+  }
+  if (typeof info.rtt === 'number' && info.rtt > 300) {
+    return 'network';
+  }
+  return 'compute';
+}
+
+export function logInteraction(event: string, duration?: number): TelemetryEvent {
+  const network = getNetworkInfo();
+  const cause = determineCause(network);
+  const payload: TelemetryEvent = { event, duration, network, cause };
+  // In a real application this would send the payload to a telemetry backend.
+  // For now we simply log to the console.
+  if (typeof console !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.log('[telemetry]', payload);
+  }
+  return payload;
+}
+
+export function logNetwork(event: string): TelemetryEvent {
+  return logInteraction(event);
+}

--- a/tests/components/media/Image.test.ts
+++ b/tests/components/media/Image.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createImage } from '../../../src/components/media/Image';
+
+describe('Image component', () => {
+  it('uses low quality source on slow connection', () => {
+    Object.defineProperty(navigator, 'connection', {
+      value: { downlink: 0.5, rtt: 500, saveData: true },
+      configurable: true,
+    });
+
+    const img = createImage({ src: 'high.png', lowQualitySrc: 'low.png' });
+    expect(img.getAttribute('src')).toBe('low.png');
+  });
+});

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { logInteraction } from '../../src/lib/telemetry';
+
+describe('telemetry', () => {
+  it('flags network as cause when connection is slow', () => {
+    Object.defineProperty(navigator, 'connection', {
+      value: { downlink: 0.5, rtt: 500, saveData: false },
+      configurable: true,
+    });
+
+    const event = logInteraction('slow');
+    expect(event.cause).toBe('network');
+  });
+
+  it('flags compute as cause when connection is fast', () => {
+    Object.defineProperty(navigator, 'connection', {
+      value: { downlink: 10, rtt: 50, saveData: false },
+      configurable: true,
+    });
+
+    const event = logInteraction('fast');
+    expect(event.cause).toBe('compute');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,10 @@
       "es6",
       "dom"
     ],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "experimentalDecorators": true,
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "jsx": "react",
+      "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary
- capture network downlink, RTT and save-data
- scale image and video sources for slow networks
- log telemetry differentiating network vs compute delays

## Testing
- `yarn test`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b3eee6dbe083289c6e9144ceea0e37