### PR TITLE
feat: add undo history manager and toast component

### DIFF
--- a/src/components/UndoToast.tsx
+++ b/src/components/UndoToast.tsx
@@ -1,0 +1,60 @@
+export interface UndoToastOptions {
+  /** Text describing the action that occurred */
+  action: string;
+  /**
+   * How long the toast should remain on screen before automatically
+   * disappearing, in milliseconds. A countdown is shown to the user
+   * indicating how long they have left to undo.
+   */
+  duration?: number;
+  /** Callback invoked if the user presses the undo button */
+  onUndo: () => void;
+}
+
+/**
+ * Minimal toast implementation showing an undo option with a countdown.
+ * The implementation does not rely on any UI library; instead it manipulates
+ * the DOM directly so that it can be used in the existing code base without
+ * additional dependencies.
+ */
+export function showUndoToast({ action, duration = 5000, onUndo }: UndoToastOptions): void {
+  const container = document.createElement('div');
+  container.className = 'undo-toast';
+
+  const message = document.createElement('span');
+  const countdown = document.createElement('span');
+  const button = document.createElement('button');
+
+  message.textContent = `${action}`;
+  button.textContent = 'Undo';
+
+  let remaining = Math.ceil(duration / 1000);
+  countdown.textContent = ` (${remaining})`;
+
+  container.appendChild(message);
+  container.appendChild(countdown);
+  container.appendChild(button);
+
+  const remove = (): void => {
+    if (container.parentElement) {
+      container.parentElement.removeChild(container);
+    }
+  };
+
+  const timer = setInterval(() => {
+    remaining -= 1;
+    countdown.textContent = ` (${remaining})`;
+    if (remaining <= 0) {
+      clearInterval(timer);
+      remove();
+    }
+  }, 1000);
+
+  button.addEventListener('click', () => {
+    clearInterval(timer);
+    remove();
+    onUndo();
+  });
+
+  document.body.appendChild(container);
+}

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,80 @@
+export interface HistoryEntry {
+  /**
+   * Human readable description of the action that produced the entry.
+   */
+  description?: string;
+  /**
+   * Arbitrary snapshot associated with the change.
+   */
+  state?: unknown;
+  /**
+   * Optional rollback handler which will be executed on undo.
+   */
+  rollback?: () => void;
+}
+
+/**
+ * Simple in-memory history manager that supports multi-step undo.
+ *
+ * Each call to {@link push} records a new {@link HistoryEntry}. Subsequent
+ * calls to {@link undo} walk the history backwards invoking entry specific
+ * rollback handlers.  The manager behaves similar to the undo stack of text
+ * editors – new actions wipe out the redo history.
+ */
+export default class HistoryManager {
+  private stack: HistoryEntry[] = [];
+
+  private pointer = -1; // index of last applied action
+
+  /**
+   * Record a new history entry.
+   * Any entries that were previously undone are discarded to mirror typical
+   * editor behaviour.
+   */
+  push(entry: HistoryEntry): void {
+    // Remove anything after the current pointer so that new actions become
+    // the new "future".
+    if (this.pointer < this.stack.length - 1) {
+      this.stack = this.stack.slice(0, this.pointer + 1);
+    }
+    this.stack.push(entry);
+    this.pointer = this.stack.length - 1;
+  }
+
+  /**
+   * Undo the specified number of steps (defaults to one).
+   * Returns the entries that were undone in the order they were reverted.
+   */
+  undo(steps = 1): HistoryEntry[] {
+    const undone: HistoryEntry[] = [];
+    while (steps > 0 && this.pointer >= 0) {
+      const current = this.stack[this.pointer];
+      if (current?.rollback) {
+        try {
+          current.rollback();
+        } catch {
+          /* ignore rollback errors */
+        }
+      }
+      undone.push(current);
+      this.pointer -= 1;
+      steps -= 1;
+    }
+    return undone;
+  }
+
+  /**
+   * Whether there are any actions that can be undone.
+   */
+  canUndo(): boolean {
+    return this.pointer >= 0;
+  }
+
+  /**
+   * Clear the entire history stack.
+   */
+  clear(): void {
+    this.stack = [];
+    this.pointer = -1;
+  }
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,11 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import { registerHistoryRoutes } from '../../server/routes/history';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    registerHistoryRoutes(app);
   }
 }

--- a/src/server/routes/history.ts
+++ b/src/server/routes/history.ts
@@ -1,0 +1,23 @@
+import HistoryManager, { HistoryEntry } from '../../lib/history';
+
+/**
+ * Registers API routes responsible for history management. The routes are kept
+ * intentionally lightweight so that they can run in development without
+ * pulling in additional dependencies.  The `app` parameter is assumed to be
+ * an Express-like instance exposing `post` methods.
+ */
+export function registerHistoryRoutes(app: any, history = new HistoryManager()): void {
+  // Record a history entry
+  app.post('/api/history/push', (req: any, res: any) => {
+    const body: HistoryEntry = req.body || {};
+    history.push(body);
+    res.json({ status: 'ok' });
+  });
+
+  // Undo one or more steps from the history
+  app.post('/api/history/undo', (req: any, res: any) => {
+    const steps = typeof req.body?.steps === 'number' ? req.body.steps : 1;
+    const undone = history.undo(steps);
+    res.json({ undone });
+  });
+}

--- a/tests/modules/HistoryManager.test.ts
+++ b/tests/modules/HistoryManager.test.ts
@@ -1,0 +1,22 @@
+import HistoryManager from '../../src/lib/history';
+
+describe('HistoryManager', () => {
+  it('supports multi-step undo', () => {
+    const history = new HistoryManager();
+    const order: number[] = [];
+
+    history.push({ description: 'one', rollback: () => order.push(1) });
+    history.push({ description: 'two', rollback: () => order.push(2) });
+    history.push({ description: 'three', rollback: () => order.push(3) });
+
+    const undone = history.undo(2);
+
+    expect(order).toStrictEqual([3, 2]);
+    expect(undone.map((u) => u.description)).toStrictEqual(['three', 'two']);
+
+    expect(history.canUndo()).toBe(true);
+    history.undo();
+    expect(order).toStrictEqual([3, 2, 1]);
+    expect(history.canUndo()).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "strict": true,
+    "jsx": "react",
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- add in-memory history manager with multi-step undo
- show DOM-based undo toast with countdown
- expose server routes for pushing and undoing history
- wire server to register history routes
- add unit test for undo history manager

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eee7eab88328a38e108c477e0740