### PR TITLE
feat: add cross-platform sharing utilities

### DIFF
--- a/src/components/QrShare.tsx
+++ b/src/components/QrShare.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from 'react';
+import QRCode from 'qrcode';
+
+export interface QrShareProps {
+  /**
+   * URL that will be encoded in the QR code
+   */
+  url: string;
+  /**
+   * Size of the QR code in pixels
+   */
+  size?: number;
+}
+
+/**
+ * Generates a QR code for sharing links.
+ * Uses a canvas element so it works across modern browsers and devices.
+ */
+const QrShare: React.FC<QrShareProps> = ({ url, size = 128 }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    QRCode.toCanvas(canvas, url, { width: size }, (error) => {
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('QR code generation failed', error);
+      }
+    });
+  }, [url, size]);
+
+  return <canvas ref={canvasRef} width={size} height={size} />;
+};
+
+export default QrShare;

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,34 @@
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return successful;
+  } catch (err) {
+    console.error('Failed to copy text', err);
+    return false;
+  }
+}
+
+export function copyUrl(url: string): Promise<boolean> {
+  return copyText(url);
+}
+
+export function copyId(id: string): Promise<boolean> {
+  return copyText(id);
+}
+
+export function copyCode(code: string): Promise<boolean> {
+  return copyText(code);
+}

--- a/src/pages/api/share.ts
+++ b/src/pages/api/share.ts
@@ -1,0 +1,28 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+interface ShareRequest extends IncomingMessage {
+  body?: any;
+  query?: any;
+}
+
+export default async function handler(req: ShareRequest, res: ServerResponse): Promise<void> {
+  const data = (req.body || req.query) || {};
+  const { title, text, url } = data;
+  const nav: any = (globalThis as any).navigator;
+
+  if (nav && typeof nav.share === 'function') {
+    try {
+      await nav.share({ title, text, url });
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ success: true }));
+    } catch (e: any) {
+      res.statusCode = 500;
+      res.end(JSON.stringify({ success: false, error: e.message }));
+    }
+  } else {
+    res.statusCode = 501;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: false, error: 'Web Share API not supported' }));
+  }
+}


### PR DESCRIPTION
## Summary
- add clipboard helpers with modern API and legacy fallback
- create API route to leverage Web Share when supported
- introduce QR code component for deep-link sharing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eeeb5ba08328b9e1a0986df66134