### PR TITLE
feat: add locale validation and preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "build": "webpack --mode=production",
     "lint": "eslint --ext .js,.ts .",
     "lint:fix": "yarn lint --fix",
-    "release": "yarn standard-version",
+    "release": "yarn locales:check && yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "locales:check": "ts-node --transpile-only scripts/check-locales.ts"
   },
   "browserslist": [
     "defaults",

--- a/scripts/check-locales.ts
+++ b/scripts/check-locales.ts
@@ -1,0 +1,67 @@
+/* eslint-disable */
+import fs from 'fs';
+import path from 'path';
+
+const localeDir = process.argv[2] || path.resolve(__dirname, '../src/locales');
+const baseLocale = process.argv[3] || 'en';
+
+function readJson(file: string): any {
+  return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+function flatten(obj: any, prefix = ''): Record<string, string> {
+  const res: Record<string, string> = {};
+  Object.keys(obj).forEach((key) => {
+    const value = obj[key];
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      Object.assign(res, flatten(value, newKey));
+    } else {
+      res[newKey] = String(value);
+    }
+  });
+  return res;
+}
+
+function placeholders(str: string): Set<string> {
+  const matches = str.match(/\{[^}]+\}/g);
+  return new Set(matches || []);
+}
+
+const basePath = path.join(localeDir, `${baseLocale}.json`);
+if (!fs.existsSync(basePath)) {
+  console.error(`Base locale "${baseLocale}" not found in ${localeDir}`);
+  process.exit(1);
+}
+
+const base = flatten(readJson(basePath));
+
+const files = fs.readdirSync(localeDir).filter((f) => f.endsWith('.json') && f !== `${baseLocale}.json`);
+let hasError = false;
+
+files.forEach((file) => {
+  const localeName = path.basename(file, '.json');
+  const target = flatten(readJson(path.join(localeDir, file)));
+  Object.keys(base).forEach((key) => {
+    if (!(key in target)) {
+      console.error(`[${localeName}] missing key: ${key}`);
+      hasError = true;
+    } else {
+      const basePh = placeholders(base[key]);
+      const targetPh = placeholders(target[key]);
+      basePh.forEach((ph) => {
+        if (!targetPh.has(ph)) {
+          console.error(`[${localeName}] placeholder mismatch for "${key}": missing ${ph}`);
+          hasError = true;
+        }
+      });
+    }
+  });
+});
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All locale files validated successfully.');
+}
+

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hello {name}",
+  "farewell": "Goodbye"
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hola {name}",
+  "farewell": "Adiós"
+}

--- a/src/pages/i18n/index.ejs
+++ b/src/pages/i18n/index.ejs
@@ -1,0 +1,1 @@
+<div id="preview"></div>

--- a/src/pages/i18n/index.scss
+++ b/src/pages/i18n/index.scss
@@ -1,0 +1,13 @@
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+
+.missing {
+  background: #fdd;
+}

--- a/src/pages/i18n/index.ts
+++ b/src/pages/i18n/index.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/extensions
+import render from './preview';
+
+render();

--- a/src/pages/i18n/preview.tsx
+++ b/src/pages/i18n/preview.tsx
@@ -1,0 +1,69 @@
+interface FlatMap { [key: string]: string; }
+
+function flatten(obj: any, prefix = ''): FlatMap {
+  const res: FlatMap = {};
+  Object.keys(obj).forEach((key) => {
+    const value = obj[key];
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      Object.assign(res, flatten(value, newKey));
+    } else {
+      res[newKey] = String(value);
+    }
+  });
+  return res;
+}
+
+async function load(code: string): Promise<any> {
+  const response = await fetch(`/locales/${code}.json`);
+  return response.json();
+}
+
+export default async function render(): Promise<void> {
+  const params = new URLSearchParams(window.location.search);
+  const target = params.get('target') || 'es';
+
+  const base = flatten(await load('en'));
+  const locale = flatten(await load(target));
+
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Key', 'Base', `Target (${target})`].forEach((text) => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  Object.keys(base).forEach((key) => {
+    const row = document.createElement('tr');
+    const k = document.createElement('td');
+    k.textContent = key;
+    row.appendChild(k);
+
+    const b = document.createElement('td');
+    b.textContent = base[key];
+    row.appendChild(b);
+
+    const t = document.createElement('td');
+    if (!(key in locale)) {
+      t.textContent = process.env.NODE_ENV !== 'production' ? '[missing]' : '';
+      row.classList.add('missing');
+    } else {
+      t.textContent = locale[key];
+    }
+    row.appendChild(t);
+
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+
+  const root = document.getElementById('preview');
+  if (root) {
+    root.innerHTML = '';
+    root.appendChild(table);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   "include": [
     "src",
     "tests",
+    "scripts",
   ],
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -90,7 +90,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
           ],
         },
         {
-          test: /\.ts$/,
+          test: /\.tsx?$/,
           use: [
             'babel-loader',
             {
@@ -121,6 +121,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
         patterns: [
           { from: 'public/export/', to: 'public/' },
           { from: 'public/favicon.ico', noErrorOnMissing: true },
+          { from: 'src/locales', to: 'locales' },
         ],
       }),
       new HtmlWebpackPlugin({
@@ -158,7 +159,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
         '@src': path.resolve(__dirname, './src'),
       },
       extensions: [
-        '.ts', '.js', '.json',
+        '.ts', '.tsx', '.js', '.json',
       ],
     },
   };


### PR DESCRIPTION
## Summary
- add script to verify locale completeness and placeholder consistency
- introduce i18n preview page to compare base and target translations
- surface missing translations during preview builds

## Testing
- `npm run lint`
- `npm test`
- `npm run locales:check`


------
https://chatgpt.com/codex/tasks/task_e_68b3eeeac5808328bb801e847fecba0e