### PR TITLE
feat: add performance watcher and CI report

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "perf:report": "ts-node ./scripts/perf-report.ts"
   },
   "browserslist": [
     "defaults",

--- a/perf-budgets.json
+++ b/perf-budgets.json
@@ -1,0 +1,12 @@
+{
+  "/": {
+    "desktop": {
+      "longTaskDuration": 200,
+      "maxMemory": 200000000
+    },
+    "mobile": {
+      "longTaskDuration": 300,
+      "maxMemory": 300000000
+    }
+  }
+}

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import axios from 'axios';
+
+interface IMetrics {
+  [route: string]: {
+    [device: string]: {
+      longTaskDuration: number;
+      maxMemory: number;
+    };
+  };
+}
+
+function readJSON(filePath: string): any {
+  const abs = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(abs)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(abs, 'utf8'));
+}
+
+const budgets: IMetrics = readJSON('perf-budgets.json');
+const current: IMetrics = readJSON('perf-results.json');
+
+let main: IMetrics = {};
+try {
+  const mainRaw = execSync('git show origin/main:perf-results.json', { encoding: 'utf8' });
+  main = JSON.parse(mainRaw);
+} catch (e) {
+  console.warn('Unable to read metrics from main branch');
+}
+
+let fail = false;
+const lines: string[] = ['| Route | Device | Long Task Δ (ms) | Memory Δ (bytes) |', '| --- | --- | --- | --- |'];
+
+Object.keys(current).forEach((route) => {
+  const devices = current[route];
+  Object.keys(devices).forEach((device) => {
+    const cur = devices[device];
+    const base = main[route]?.[device] || { longTaskDuration: 0, maxMemory: 0 };
+    const budget = budgets[route]?.[device];
+
+    const longDelta = cur.longTaskDuration - base.longTaskDuration;
+    const memDelta = cur.maxMemory - base.maxMemory;
+
+    if (budget) {
+      if (cur.longTaskDuration > budget.longTaskDuration || cur.maxMemory > budget.maxMemory) {
+        fail = true;
+      }
+    }
+
+    lines.push(`| ${route} | ${device} | ${longDelta.toFixed(2)} | ${memDelta} |`);
+  });
+});
+
+const commentBody = lines.join('\n');
+console.log(commentBody);
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY; // e.g. owner/repo
+const prNumber = process.env.PR_NUMBER;
+
+if (token && repo && prNumber) {
+  axios.post(`https://api.github.com/repos/${repo}/issues/${prNumber}/comments`, {
+    body: commentBody,
+  }, {
+    headers: {
+      Authorization: `token ${token}`,
+      'Content-Type': 'application/json',
+    },
+  }).catch((err) => {
+    console.warn('Failed to post comment', err.message);
+  });
+}
+
+if (fail) {
+  console.error('Performance budgets exceeded');
+  process.exit(1);
+}

--- a/src/lib/perfWatcher.ts
+++ b/src/lib/perfWatcher.ts
@@ -1,0 +1,92 @@
+export interface IPerfMetrics {
+  longTaskDuration: number; // total duration in ms
+  longTaskCount: number; // number of long tasks
+  maxMemory: number; // max memory used in bytes
+}
+
+/**
+ * PerformanceWatcher observes long tasks and samples memory usage
+ * over time. It is intended to run in the browser where the
+ * PerformanceObserver and performance.memory APIs are available.
+ */
+export default class PerformanceWatcher {
+  private longTaskDuration = 0;
+
+  private longTaskCount = 0;
+
+  private maxMemory = 0;
+
+  private longTaskObserver?: PerformanceObserver;
+
+  private memoryInterval?: number;
+
+  private readonly sampleRate: number;
+
+  constructor(sampleRate = 1000) {
+    this.sampleRate = sampleRate;
+  }
+
+  /**
+   * Start observing performance metrics.
+   */
+  start(): void {
+    if (typeof window !== 'undefined' && 'PerformanceObserver' in window) {
+      try {
+        this.longTaskObserver = new PerformanceObserver((list) => {
+          list.getEntries().forEach((entry) => {
+            this.longTaskDuration += entry.duration;
+            this.longTaskCount += 1;
+          });
+        });
+        // Chrome supports the 'longtask' type directly.
+        (this.longTaskObserver as PerformanceObserver).observe({
+          entryTypes: ['longtask'],
+        });
+      } catch (e) {
+        // Ignore if PerformanceObserver isn't available or throws.
+      }
+    }
+
+    if (typeof window !== 'undefined' &&
+      typeof performance !== 'undefined' &&
+      (performance as any).memory) {
+      this.maxMemory = (performance as any).memory.usedJSHeapSize;
+      this.memoryInterval = window.setInterval(() => {
+        const current = (performance as any).memory.usedJSHeapSize;
+        if (current > this.maxMemory) {
+          this.maxMemory = current;
+        }
+      }, this.sampleRate);
+    }
+  }
+
+  /**
+   * Stop observing and return collected metrics.
+   */
+  stop(): IPerfMetrics {
+    if (this.longTaskObserver) {
+      this.longTaskObserver.disconnect();
+    }
+
+    if (this.memoryInterval) {
+      clearInterval(this.memoryInterval);
+    }
+
+    // Sample once more on stop to capture final memory usage.
+    if (typeof window !== 'undefined' &&
+      typeof performance !== 'undefined' &&
+      (performance as any).memory) {
+      const current = (performance as any).memory.usedJSHeapSize;
+      if (current > this.maxMemory) {
+        this.maxMemory = current;
+      }
+    }
+
+    return {
+      longTaskDuration: this.longTaskDuration,
+      longTaskCount: this.longTaskCount,
+      maxMemory: this.maxMemory,
+    };
+  }
+}
+


### PR DESCRIPTION
## Summary
- add browser PerformanceWatcher for long tasks and memory usage
- track perf budgets and create perf report script comparing against main

## Testing
- `yarn test`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn perf:report` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f7ada4748328be6fa0ce881a8ece