### PR TITLE
feat: add snapshot serialization and import dialog

### DIFF
--- a/src/lib/importDialog.ts
+++ b/src/lib/importDialog.ts
@@ -1,0 +1,69 @@
+import { SnapshotState, WindowPosition, deserializeState } from './snapshot';
+
+export interface PositionDiff {
+  from: WindowPosition;
+  to: WindowPosition;
+}
+
+export interface StateDiff {
+  windowsAdded: string[];
+  windowsRemoved: string[];
+  windowPositionChanged: Record<string, PositionDiff>;
+  appChanges: Record<string, { from: unknown; to: unknown }>;
+}
+
+export function validateToken(token: string): boolean {
+  try {
+    deserializeState(token);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function previewStateDiff(current: SnapshotState, incoming: SnapshotState): StateDiff {
+  const diff: StateDiff = {
+    windowsAdded: [],
+    windowsRemoved: [],
+    windowPositionChanged: {},
+    appChanges: {},
+  };
+
+  const currentWindows = new Map(current.windows.map((w) => [w.id, w]));
+  const incomingWindows = new Map(incoming.windows.map((w) => [w.id, w]));
+
+  incomingWindows.forEach((win, id) => {
+    const existing = currentWindows.get(id);
+    if (!existing) {
+      diff.windowsAdded.push(id);
+    } else if (existing.position.x !== win.position.x || existing.position.y !== win.position.y) {
+      diff.windowPositionChanged[id] = {
+        from: existing.position,
+        to: win.position,
+      };
+    }
+  });
+
+  currentWindows.forEach((_, id) => {
+    if (!incomingWindows.has(id)) {
+      diff.windowsRemoved.push(id);
+    }
+  });
+
+  const keys = new Set([...Object.keys(current.app), ...Object.keys(incoming.app)]);
+  keys.forEach((key) => {
+    const curVal = (current.app as any)[key];
+    const incVal = (incoming.app as any)[key];
+    if (JSON.stringify(curVal) !== JSON.stringify(incVal)) {
+      diff.appChanges[key] = { from: curVal, to: incVal };
+    }
+  });
+
+  return diff;
+}
+
+export function importSnapshot(token: string, current: SnapshotState): { state: SnapshotState; diff: StateDiff } {
+  const incoming = deserializeState(token);
+  const diff = previewStateDiff(current, incoming);
+  return { state: incoming, diff };
+}

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,92 @@
+export interface WindowPosition {
+  x: number;
+  y: number;
+}
+
+export interface WindowState {
+  id: string;
+  position: WindowPosition;
+}
+
+export interface SnapshotState {
+  version: number;
+  windows: WindowState[];
+  positions: Record<string, WindowPosition>;
+  app: Record<string, unknown>;
+}
+
+export const CURRENT_SNAPSHOT_VERSION = 2;
+
+function toBase64Url(str: string): string {
+  return Buffer.from(str, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+}
+
+function fromBase64Url(str: string): string {
+  const base64 = str
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+  const pad = base64.length % 4;
+  const padded = base64 + (pad ? '='.repeat(4 - pad) : '');
+  return Buffer.from(padded, 'base64').toString('utf8');
+}
+
+export interface SerializableState {
+  windows: WindowState[];
+  positions: Record<string, WindowPosition>;
+  app: Record<string, unknown>;
+}
+
+export function serializeState(state: SerializableState): string {
+  const payload: SnapshotState = {
+    version: CURRENT_SNAPSHOT_VERSION,
+    windows: state.windows,
+    positions: state.positions,
+    app: state.app,
+  };
+
+  return toBase64Url(JSON.stringify(payload));
+}
+
+export function deserializeState(token: string): SnapshotState {
+  let raw: any;
+
+  try {
+    raw = JSON.parse(fromBase64Url(token));
+  } catch (e) {
+    throw new Error('Invalid snapshot token');
+  }
+
+  const version: number = typeof raw.version === 'number' ? raw.version : 1;
+
+  if (version === 1) {
+    const winArray: WindowState[] = Array.isArray(raw.windows) ? raw.windows : [];
+    const positions: Record<string, WindowPosition> = {};
+    winArray.forEach((w) => {
+      if (w && typeof w.id === 'string' && w.position) {
+        positions[w.id] = w.position;
+      }
+    });
+
+    return {
+      version: CURRENT_SNAPSHOT_VERSION,
+      windows: winArray,
+      positions,
+      app: raw.app ?? {},
+    };
+  }
+
+  if (version === 2 || version === CURRENT_SNAPSHOT_VERSION) {
+    return {
+      version: CURRENT_SNAPSHOT_VERSION,
+      windows: Array.isArray(raw.windows) ? raw.windows : [],
+      positions: raw.positions ?? {},
+      app: raw.app ?? {},
+    };
+  }
+
+  throw new Error(`Unsupported snapshot version: ${version}`);
+}

--- a/tests/lib/snapshot.test.ts
+++ b/tests/lib/snapshot.test.ts
@@ -1,0 +1,90 @@
+import { serializeState, deserializeState, CURRENT_SNAPSHOT_VERSION, SnapshotState } from '../../src/lib/snapshot';
+import { validateToken, previewStateDiff, importSnapshot } from '../../src/lib/importDialog';
+
+describe('snapshot serialization', () => {
+  it('round trip serialization', () => {
+    const state = {
+      windows: [{ id: 'w1', position: { x: 1, y: 2 } }],
+      positions: { w1: { x: 1, y: 2 } },
+      app: { foo: 'bar' },
+    };
+
+    const token = serializeState(state);
+    const decoded = deserializeState(token);
+
+    expect(decoded).toEqual({
+      version: CURRENT_SNAPSHOT_VERSION,
+      windows: state.windows,
+      positions: state.positions,
+      app: state.app,
+    });
+  });
+
+  it('deserializes version 1 token', () => {
+    const legacy = {
+      version: 1,
+      windows: [{ id: 'w1', position: { x: 5, y: 6 } }],
+      app: { foo: 'bar' },
+    };
+    const legacyToken = Buffer.from(JSON.stringify(legacy), 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/u, '');
+
+    const decoded = deserializeState(legacyToken);
+
+    expect(decoded.windows.length).toBe(1);
+    expect(decoded.positions).toEqual({ w1: { x: 5, y: 6 } });
+    expect(decoded.app).toEqual({ foo: 'bar' });
+    expect(decoded.version).toBe(CURRENT_SNAPSHOT_VERSION);
+  });
+});
+
+describe('import dialog', () => {
+  const baseState: SnapshotState = {
+    version: CURRENT_SNAPSHOT_VERSION,
+    windows: [{ id: 'a', position: { x: 0, y: 0 } }],
+    positions: { a: { x: 0, y: 0 } },
+    app: { foo: 'bar' },
+  };
+
+  it('validates token correctly', () => {
+    const token = serializeState(baseState);
+    expect(validateToken(token)).toBeTruthy();
+    expect(validateToken('badtoken')).toBeFalsy();
+  });
+
+  it('previews diff', () => {
+    const incoming: SnapshotState = {
+      version: CURRENT_SNAPSHOT_VERSION,
+      windows: [
+        { id: 'a', position: { x: 1, y: 1 } },
+        { id: 'b', position: { x: 0, y: 0 } },
+      ],
+      positions: { a: { x: 1, y: 1 }, b: { x: 0, y: 0 } },
+      app: { foo: 'baz' },
+    };
+
+    const diff = previewStateDiff(baseState, incoming);
+
+    expect(diff.windowsAdded).toEqual(['b']);
+    expect(diff.windowsRemoved).toEqual([]);
+    expect(diff.windowPositionChanged.a.from).toEqual({ x: 0, y: 0 });
+    expect(diff.windowPositionChanged.a.to).toEqual({ x: 1, y: 1 });
+    expect(diff.appChanges.foo.from).toBe('bar');
+    expect(diff.appChanges.foo.to).toBe('baz');
+  });
+
+  it('importSnapshot returns incoming state and diff', () => {
+    const incomingState = {
+      windows: [{ id: 'a', position: { x: 2, y: 2 } }],
+      positions: { a: { x: 2, y: 2 } },
+      app: { foo: 'qux' },
+    };
+    const token = serializeState(incomingState);
+    const result = importSnapshot(token, baseState);
+    expect(result.state.app.foo).toBe('qux');
+    expect(result.diff.windowPositionChanged.a.to).toEqual({ x: 2, y: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- add snapshot serializer/deserializer with URL-safe base64 and schema versioning
- provide import utilities for validating tokens and previewing state diffs
- cover snapshot round-trip and version-compat tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3f7ae4e2883288bd52e52e7b37ba4