### PR TITLE
feat: add internal analytics tracker

### DIFF
--- a/config/analytics.json
+++ b/config/analytics.json
@@ -1,0 +1,3 @@
+{
+  "sampleRate": 1
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,100 @@
+/*
+ * Simple internal analytics tracker.
+ * Counts page views and custom actions using a hashed session id.
+ * Respects browser do not track preference and supports sampling.
+ */
+
+interface AnalyticsStore {
+  pages: Record<string, number>;
+  actions: Record<string, number>;
+}
+
+export default class AnalyticsTracker {
+  private enabled: boolean;
+
+  private sessionId: string | null = null;
+
+  private store: AnalyticsStore;
+
+  constructor() {
+    const { sampleRate } = require('../../config/analytics.json');
+    this.enabled = this.shouldTrack(Number(sampleRate));
+    this.store = this.load();
+
+    if (this.enabled) {
+      this.sessionId = this.getSessionId();
+    }
+  }
+
+  private shouldTrack(sampleRate: number): boolean {
+    const dnt = (navigator as any).doNotTrack === '1'
+      || (navigator as any).msDoNotTrack === '1'
+      || (window as any).doNotTrack === '1';
+
+    if (dnt) {
+      return false;
+    }
+
+    return Math.random() < sampleRate;
+  }
+
+  private getSessionId(): string {
+    const existing = sessionStorage.getItem('analyticsSession');
+    if (existing) {
+      return existing;
+    }
+
+    const raw = `${Date.now()}-${Math.random()}`;
+    let hash = 0;
+    for (let i = 0; i < raw.length; i += 1) {
+      hash = ((hash << 5) - hash) + raw.charCodeAt(i);
+      hash |= 0; // Convert to 32bit integer
+    }
+    const id = hash.toString(16);
+    sessionStorage.setItem('analyticsSession', id);
+    return id;
+  }
+
+  private load(): AnalyticsStore {
+    try {
+      const json = localStorage.getItem('analytics');
+      if (json) {
+        return JSON.parse(json);
+      }
+    } catch (_) {
+      // ignore
+    }
+    return { pages: {}, actions: {} };
+  }
+
+  private save(): void {
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      localStorage.setItem('analytics', JSON.stringify(this.store));
+    } catch (_) {
+      // ignore write errors
+    }
+  }
+
+  trackPage(route: string): void {
+    if (!this.enabled) {
+      return;
+    }
+    this.store.pages[route] = (this.store.pages[route] || 0) + 1;
+    this.save();
+  }
+
+  trackAction(action: string): void {
+    if (!this.enabled) {
+      return;
+    }
+    this.store.actions[action] = (this.store.actions[action] || 0) + 1;
+    this.save();
+  }
+
+  summary(): AnalyticsStore {
+    return { ...this.store };
+  }
+}

--- a/src/pages/admin/analytics.tsx
+++ b/src/pages/admin/analytics.tsx
@@ -1,0 +1,38 @@
+import AnalyticsTracker from '../../lib/analytics';
+
+function createTable(title: string, data: Record<string, number>): HTMLElement {
+  const wrapper = document.createElement('div');
+  const heading = document.createElement('h2');
+  heading.textContent = title;
+  wrapper.appendChild(heading);
+
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+
+  Object.keys(data).forEach((key) => {
+    const tr = document.createElement('tr');
+    const tdKey = document.createElement('td');
+    tdKey.textContent = key;
+    const tdVal = document.createElement('td');
+    tdVal.textContent = data[key].toString();
+    tr.appendChild(tdKey);
+    tr.appendChild(tdVal);
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  return wrapper;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tracker = new AnalyticsTracker();
+  const summary = tracker.summary();
+
+  const root = document.getElementById('analytics');
+  if (!root) {
+    return;
+  }
+  root.appendChild(createTable('Page Views', summary.pages));
+  root.appendChild(createTable('Actions', summary.actions));
+});


### PR DESCRIPTION
## Summary
- add lightweight AnalyticsTracker capturing page views and actions with hashed session ids
- respect `navigator.doNotTrack` and support configurable sampling rate
- provide admin dashboard to review stored analytics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3f7b010048328be757ca07edab359