### PR TITLE
feat: improve anchor navigation

### DIFF
--- a/src/templates/_common/scripts/anchors.ts
+++ b/src/templates/_common/scripts/anchors.ts
@@ -1,0 +1,62 @@
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function getHeaderOffset(): number {
+  const header = document.querySelector<HTMLElement>('.header');
+  return header ? header.getBoundingClientRect().height : 0;
+}
+
+export function scrollToTarget(target: HTMLElement): void {
+  const offset = getHeaderOffset();
+  const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
+  window.scrollTo({ top, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
+}
+
+export function handleHash(hash: string): void {
+  const id = decodeURIComponent(hash.replace(/^#/, ''));
+  const target = document.getElementById(id);
+  if (target) {
+    scrollToTarget(target);
+  }
+}
+
+export default function initAnchors(): void {
+  // initial deep link
+  if (window.location.hash) {
+    handleHash(window.location.hash);
+  }
+
+  // offset for html
+  document.documentElement.style.setProperty('--scroll-padding-top', `${getHeaderOffset()}px`);
+  window.addEventListener('resize', () => {
+    document.documentElement.style.setProperty('--scroll-padding-top', `${getHeaderOffset()}px`);
+  });
+
+  // intercept anchor clicks
+  document.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((link) => {
+    link.addEventListener('click', (e) => {
+      const href = link.getAttribute('href');
+      if (href && href.startsWith('#')) {
+        e.preventDefault();
+        handleHash(href);
+        history.pushState(null, '', href);
+      }
+    });
+  });
+
+  // copy buttons for headings
+  document.querySelectorAll<HTMLElement>('h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]').forEach((heading) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'hash-link';
+    button.textContent = '#';
+    button.addEventListener('click', () => {
+      const url = `${location.origin}${location.pathname}#${heading.id}`;
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(url);
+      }
+    });
+    heading.appendChild(button);
+  });
+}

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,11 @@
+import initAnchors from './anchors';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });
   }
+
+  initAnchors();
 })();

--- a/src/templates/default/styles/global.scss
+++ b/src/templates/default/styles/global.scss
@@ -26,3 +26,32 @@ li {
 h1 {
   font-size: 2.625rem;
 }
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: var(--scroll-padding-top, 0px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+button.hash-link {
+  margin-left: .5rem;
+  background: none;
+  border: none;
+  opacity: 0;
+  cursor: pointer;
+}
+
+h1:hover .hash-link,
+h2:hover .hash-link,
+h3:hover .hash-link,
+h4:hover .hash-link,
+h5:hover .hash-link,
+h6:hover .hash-link,
+button.hash-link:focus {
+  opacity: 1;
+}

--- a/tests/templates/anchors.test.ts
+++ b/tests/templates/anchors.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import initAnchors from '../../src/templates/_common/scripts/anchors';
+
+describe('anchors', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <header class="header"></header>
+      <main>
+        <h2 id="target">Target</h2>
+      </main>
+    `;
+
+    const header = document.querySelector('.header') as HTMLElement;
+    header.getBoundingClientRect = () => ({
+      width: 0,
+      height: 50,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 50,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const target = document.getElementById('target') as HTMLElement;
+    target.getBoundingClientRect = () => ({
+      width: 0,
+      height: 0,
+      top: 300,
+      left: 0,
+      right: 0,
+      bottom: 300,
+      x: 0,
+      y: 300,
+      toJSON: () => {},
+    });
+
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false, addListener: jest.fn(), removeListener: jest.fn() });
+    Object.assign(navigator, { clipboard: { writeText: jest.fn() } });
+    window.scrollTo = jest.fn();
+    window.location.hash = '#target';
+  });
+
+  it('scrolls to hashed element with offset', () => {
+    initAnchors();
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 250, behavior: 'smooth' });
+  });
+});


### PR DESCRIPTION
## Summary
- add smooth scrolling with reduced-motion fallback
- offset anchor scrolling to account for sticky header and add heading copy buttons
- test deep-link navigation to ensure anchors land visibly without jitter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd3a1d548328af88f039010ad679