### PR TITLE
feat: add geolocation and reverse geocode

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,58 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import axios from 'axios';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    const cache = new Map<string, { expires: number; data: any }>();
+    const limits = new Map<string, { count: number; time: number }>();
+
+    app.get('/api/reverse-geocode', async (req, res) => {
+      const { lat, lng } = req.query as { lat?: string; lng?: string };
+
+      if (!lat || !lng) {
+        res.status(400).json({ error: 'Missing coordinates' });
+        return;
+      }
+
+      const ip = req.ip || 'unknown';
+      const now = Date.now();
+      const limit = limits.get(ip);
+
+      if (limit && now - limit.time < 60_000 && limit.count >= 10) {
+        res.status(429).json({ error: 'Rate limit exceeded' });
+        return;
+      }
+
+      if (!limit || now - limit.time >= 60_000) {
+        limits.set(ip, { count: 1, time: now });
+      } else {
+        limits.set(ip, { count: limit.count + 1, time: limit.time });
+      }
+
+      const key = `${lat},${lng}`;
+      const cached = cache.get(key);
+      if (cached && cached.expires > now) {
+        res.json(cached.data);
+        return;
+      }
+
+      try {
+        const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`;
+        const { data } = await axios.get(url, {
+          headers: {
+            'User-Agent': 'gportfolio/1.0',
+          },
+        });
+
+        const result = { address: data.display_name };
+        cache.set(key, { data: result, expires: now + 86_400_000 });
+        res.json(result);
+      } catch (e) {
+        res.status(500).json({ error: 'Failed to fetch address' });
+      }
+    });
   }
 }

--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -85,5 +85,24 @@
         </div>
     </div>
 </section>
+<section id="location-section">
+    <div class="section--name">Location</div>
+    <div class="section--items">
+        <div class="block">
+            <div class="block--label">Choose Location</div>
+            <div class="block--input">
+                <button id="use-location">Use my location</button>
+                <div id="map" data-static-src="https://via.placeholder.com/600x300?text=Map"></div>
+                <div id="address"></div>
+                <input type="hidden" id="latitude" />
+                <input type="hidden" id="longitude" />
+                <button id="save-location" style="display:none">Save Location</button>
+            </div>
+            <div class="block--description">
+                Allow access to your location to set coordinates.
+            </div>
+        </div>
+    </div>
+</section>
 </body>
 </html>

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,65 @@
 (() => {
-  console.log('dev');
+  const mapContainer = document.getElementById('map') as HTMLElement | null;
+  const useBtn = document.getElementById('use-location');
+  const saveBtn = document.getElementById('save-location') as HTMLButtonElement | null;
+  const addressDiv = document.getElementById('address');
+  const latInput = document.getElementById('latitude') as HTMLInputElement | null;
+  const lngInput = document.getElementById('longitude') as HTMLInputElement | null;
+
+  function showStatic(): void {
+    if (!mapContainer) return;
+    const img = document.createElement('img');
+    img.loading = 'lazy';
+    img.alt = 'Map placeholder';
+    img.src = mapContainer.dataset.staticSrc || '';
+    mapContainer.appendChild(img);
+  }
+
+  async function showMap(lat: number, lng: number): Promise<void> {
+    if (!mapContainer) return;
+    const iframe = document.createElement('iframe');
+    iframe.loading = 'lazy';
+    iframe.width = '100%';
+    iframe.height = '300';
+    iframe.src = `https://www.openstreetmap.org/export/embed.html?marker=${lat},${lng}&zoom=14`;
+    mapContainer.innerHTML = '';
+    mapContainer.appendChild(iframe);
+
+    if (addressDiv) {
+      try {
+        const resp = await fetch(`/api/reverse-geocode?lat=${lat}&lng=${lng}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          addressDiv.textContent = data.address;
+        }
+      } catch (e) {
+        addressDiv.textContent = 'Address unavailable';
+      }
+    }
+
+    if (latInput) latInput.value = `${lat}`;
+    if (lngInput) lngInput.value = `${lng}`;
+    if (saveBtn) saveBtn.style.display = 'block';
+  }
+
+  showStatic();
+
+  if (useBtn) {
+    useBtn.addEventListener('click', () => {
+      if (!navigator.geolocation) {
+        alert('Geolocation not supported');
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const { latitude, longitude } = pos.coords;
+          showMap(latitude, longitude);
+        },
+        () => {
+          alert('Unable to retrieve location');
+        },
+      );
+    });
+  }
 })();


### PR DESCRIPTION
## Summary
- add reverse geocode API endpoint with caching and rate limiting
- add lazy-loaded map with geolocation workflow on config page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd3b2bc88328aa15a04949bd29e2