### PR TITLE
feat: add caching headers and hashed assets

### DIFF
--- a/api/headers.ts
+++ b/api/headers.ts
@@ -1,0 +1,6 @@
+export default function handler(req: any, res: any) {
+  res.setHeader('Cache-Control', 'no-store');
+  res.json({
+    'accept-encoding': req.headers['accept-encoding'] || null,
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,38 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } },
+    { "src": "api/**/*.ts", "use": "@vercel/node" }
+  ],
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/public/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/dist/$1" }
+  ]
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -57,6 +57,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
             {
               loader: 'file-loader',
               options: {
+                name: '[name].[contenthash].[ext]',
                 outputPath: 'static/images',
               },
             },
@@ -68,6 +69,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
             {
               loader: 'file-loader',
               options: {
+                name: '[name].[contenthash].[ext]',
                 outputPath: 'static/files',
               },
             },
@@ -111,8 +113,8 @@ export default (env: any, argv: { mode: string; }): Configuration => {
       ],
     },
     output: {
-      chunkFilename: 'static/js/[name].[fullhash].js',
-      filename: 'static/[name].[fullhash].js',
+      chunkFilename: 'static/js/[name].[contenthash].js',
+      filename: 'static/js/[name].[contenthash].js',
       path: path.resolve(__dirname, 'dist'),
       publicPath: '/',
     },
@@ -148,8 +150,8 @@ export default (env: any, argv: { mode: string; }): Configuration => {
         },
       }),
       new MiniCssExtractPlugin({
-        chunkFilename: 'static/css/[name].[fullhash].css',
-        filename: 'static/[name].[fullhash].css',
+        chunkFilename: 'static/css/[name].[contenthash].css',
+        filename: 'static/css/[name].[contenthash].css',
       }),
     ] as WebpackPluginInstance[],
     resolve: {


### PR DESCRIPTION
## Summary
- add API check route for verifying response headers
- configure Vercel headers to cache static assets aggressively
- generate content-hashed filenames for emitted assets

## Testing
- `npx jest --runInBand`
- `curl -i http://localhost:3100/`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd3fa32c8328a1d53ad6ee3424ad