### PR TITLE
feat: prioritize hero images

### DIFF
--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -48,20 +48,14 @@ function generateRepositoriesHtml(repositories) {
 <html <%= require('../_common/templates/html-attributes.ejs')({ templateName: 'default' }) %>>
 <head>
   <%= require('../_common/templates/header/full.ejs')() %>
-  <style>
-    .avatar--image {
-      background: url(<%= resolveFile(config.data.avatar) %>);
-    }
-    .background--image {
-      background: url(<%= resolveFile(config.templates.default.configuration.background) %>);
-    }
-  </style>
 </head>
 <body>
 <header class="header">
-  <div class="header__background background--image"></div>
+  <div class="header__background">
+    <img src="<%= resolveFile(config.templates.default.configuration.background) %>" alt="" fetchpriority="high">
+  </div>
   <div class="header__wrap">
-    <div class="header__wrap__image avatar--image"></div>
+    <img class="header__wrap__image" src="<%= resolveFile(config.data.avatar) %>" alt="Avatar" fetchpriority="high">
     <h1 class="header__wrap__name"><%= `${config.data.first_name} ${config.data.last_name}` %></h1>
     <% if (config.data.position) { %>
       <span class="header__wrap__position"><%= config.data.position %></span>

--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -9,10 +9,12 @@
     width: 100%;
     height: 100%;
     z-index: -1;
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: cover;
-    will-change: background-position;
+    overflow: hidden;
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
     &:before {
       content: "";
       position: absolute;
@@ -30,9 +32,8 @@
       height: 200px;
       margin: 0 auto;
       border-radius: 20px;
-      background-position: 50% 50%;
-      background-repeat: no-repeat;
-      background-size: cover;
+      object-fit: cover;
+      display: block;
     }
     &__name {
       margin: 35px 0 5px;


### PR DESCRIPTION
## Summary
- use <img> tags with `fetchpriority="high"` for background and avatar images
- drop inline background preloads to avoid unused preloads

## Testing
- `curl -I --http3 https://alex-unnippillil.github.io` *(fails: option --http3: the installed libcurl version doesn't support this)*
- `yarn lint` *(no output)*
- `yarn test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd41d6888328b8e6ae2cc1417d0a