### PR TITLE
Optimize off-screen rendering for smoother scroll

### DIFF
--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -12,7 +12,6 @@
     background-position: 50% 50%;
     background-repeat: no-repeat;
     background-size: cover;
-    will-change: background-position;
     &:before {
       content: "";
       position: absolute;

--- a/src/templates/default/styles/repositories.scss
+++ b/src/templates/default/styles/repositories.scss
@@ -1,3 +1,9 @@
+.repositories-section {
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-size: 1000px;
+}
+
 .repositories {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -15,6 +21,7 @@
 }
 
 .repository {
+  contain: layout paint;
   display: flex;
   flex-direction: column;
   color: rgba(0, 0, 0, .9);


### PR DESCRIPTION
## Summary
- lazy-render heavy repository section with `content-visibility: auto`
- contain repository widgets to limit layout and style impact
- drop unnecessary `will-change` hint on header background

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd42a720832894f0387b6bee7968