### PR TITLE
feat: restore scroll and focus per tab

### DIFF
--- a/public/scroll-focus-restoration.js
+++ b/public/scroll-focus-restoration.js
@@ -1,0 +1,37 @@
+(function(){
+  const TAB_ID_KEY = 'scroll-focus-tab-id';
+  function getTabId(){
+    let id = sessionStorage.getItem(TAB_ID_KEY);
+    if(!id){
+      id = Date.now()+"-"+Math.random();
+      sessionStorage.setItem(TAB_ID_KEY,id);
+    }
+    return id;
+  }
+  function stateKey(path){
+    return getTabId()+":"+path;
+  }
+  function setup(){
+    try{history.scrollRestoration='manual';}catch(e){}
+    function save(){
+      var active = document.activeElement;
+      var data={x:window.scrollX,y:window.scrollY,focusId:active&&active.id?active.id:null};
+      try{sessionStorage.setItem(stateKey(location.pathname+location.search),JSON.stringify(data));}catch(e){}
+    }
+    function restore(){
+      var raw=sessionStorage.getItem(stateKey(location.pathname+location.search));
+      if(!raw)return;
+      try{
+        var d=JSON.parse(raw);
+        window.scrollTo(d.x||0,d.y||0);
+        if(d.focusId){
+          var el=document.getElementById(d.focusId);
+          if(el) el.focus();
+        }
+      }catch(e){}
+    }
+    addEventListener('pagehide',save);
+    addEventListener('pageshow',restore);
+  }
+  window.setupScrollFocusRestoration = setup;
+})();

--- a/public/test-bfcache-a.html
+++ b/public/test-bfcache-a.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>BFCache Test A</title>
+  <script src="./scroll-focus-restoration.js"></script>
+  <script>setupScrollFocusRestoration();</script>
+  <style>body{height:2000px;margin:0;padding:20px;}</style>
+</head>
+<body>
+  <h1>Page A</h1>
+  <p>Scroll down, focus the input, navigate to page B and go back using browser back to test restoration.</p>
+  <a href="test-bfcache-b.html" id="next">Go to Page B</a>
+  <div style="margin-top:1000px;">
+    <input id="focusme" type="text" placeholder="Focus me" />
+  </div>
+</body>
+</html>

--- a/public/test-bfcache-b.html
+++ b/public/test-bfcache-b.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>BFCache Test B</title>
+  <script src="./scroll-focus-restoration.js"></script>
+  <script>setupScrollFocusRestoration();</script>
+  <style>body{margin:0;padding:20px;}</style>
+</head>
+<body>
+  <h1>Page B</h1>
+  <a href="test-bfcache-a.html">Back to Page A</a>
+</body>
+</html>

--- a/src/utils/ScrollFocusRestoration.ts
+++ b/src/utils/ScrollFocusRestoration.ts
@@ -1,0 +1,58 @@
+const TAB_ID_KEY = 'scroll-focus-tab-id';
+
+function getTabId(): string {
+  let id = sessionStorage.getItem(TAB_ID_KEY);
+  if (!id) {
+    id = `${Date.now()}-${Math.random()}`;
+    sessionStorage.setItem(TAB_ID_KEY, id);
+  }
+  return id;
+}
+
+function stateKey(path: string): string {
+  return `${getTabId()}:${path}`;
+}
+
+export function setupScrollFocusRestoration(): void {
+  try {
+    window.history.scrollRestoration = 'manual';
+  } catch (e) {
+    // ignore
+  }
+
+  const saveState = (): void => {
+    const active = document.activeElement as HTMLElement | null;
+    const data = {
+      x: window.scrollX,
+      y: window.scrollY,
+      focusId: active && active.id ? active.id : null,
+    };
+    try {
+      sessionStorage.setItem(stateKey(window.location.pathname + window.location.search), JSON.stringify(data));
+    } catch (e) {
+      // ignore storage errors
+    }
+  };
+
+  const restoreState = (): void => {
+    const raw = sessionStorage.getItem(stateKey(window.location.pathname + window.location.search));
+    if (!raw) return;
+    try {
+      const { x, y, focusId } = JSON.parse(raw);
+      window.scrollTo(x || 0, y || 0);
+      if (focusId) {
+        const el = document.getElementById(focusId);
+        if (el) {
+          (el as HTMLElement).focus();
+        }
+      }
+    } catch (e) {
+      // ignore parse errors
+    }
+  };
+
+  window.addEventListener('pagehide', saveState);
+  window.addEventListener('pageshow', restoreState);
+}
+
+export default { setupScrollFocusRestoration };

--- a/tests/utils/ScrollFocusRestoration.test.ts
+++ b/tests/utils/ScrollFocusRestoration.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { setupScrollFocusRestoration } from '../../src/utils/ScrollFocusRestoration';
+
+describe('ScrollFocusRestoration', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  it('saves and restores scroll position and focus', () => {
+    const input = document.createElement('input');
+    input.id = 'field';
+    document.body.appendChild(input);
+    input.focus();
+
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 10, writable: true });
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 20, writable: true });
+
+    setupScrollFocusRestoration();
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    Object.defineProperty(window, 'scrollTo', {
+      value: (x: number, y: number) => {
+        Object.defineProperty(window, 'scrollX', { configurable: true, value: x, writable: true });
+        Object.defineProperty(window, 'scrollY', { configurable: true, value: y, writable: true });
+      },
+      configurable: true,
+    });
+
+    input.blur();
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 0, writable: true });
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0, writable: true });
+
+    window.dispatchEvent(new Event('pageshow'));
+
+    expect(window.scrollX).toBe(10);
+    expect(window.scrollY).toBe(20);
+    expect(document.activeElement).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- add scroll/focus restoration tied to unique tab keys
- add test page to demo back-forward cache restoration
- cover scroll/focus persistence with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd4733308328a7e72598cb7517e4