### PR TITLE
Add head manager with canonical and meta tag dedup

### DIFF
--- a/src/di.ts
+++ b/src/di.ts
@@ -18,6 +18,7 @@ import IApplication from './interfaces/IApplication';
 import Application from './Application';
 import config from '../config';
 import IConfig from './interfaces/IConfig';
+import HeadManager from './modules/head/HeadManager';
 
 const di = new Container();
 
@@ -36,6 +37,8 @@ di.bind<IFilterCompareItem>(TYPES.FilterCompareItems).to(RegExpCompareItem);
 
 di.bind<ILogger>(TYPES.Logger).to(ConsoleLogger);
 di.bind<IPrefixLogger>(TYPES.LoggerPrefix).toDynamicValue(() => new ConsolePrefixLogger('application'));
+
+di.bind<HeadManager>(TYPES.HeadManager).to(HeadManager).inSingletonScope();
 
 // Services
 githubService(di);

--- a/src/modules/head/HeadManager.ts
+++ b/src/modules/head/HeadManager.ts
@@ -1,0 +1,74 @@
+import { injectable } from 'inversify';
+
+export interface MetaAttributes {
+  name?: string;
+  property?: string;
+  content: string;
+}
+
+@injectable()
+export default class HeadManager {
+  private canonicalUrl?: string;
+
+  private titleText?: string;
+
+  private metas: Map<string, MetaAttributes> = new Map();
+
+  reset(): void {
+    this.canonicalUrl = undefined;
+    this.titleText = undefined;
+    this.metas.clear();
+  }
+
+  canonical(url: string): void {
+    this.canonicalUrl = url;
+  }
+
+  title(text: string): void {
+    this.titleText = text;
+  }
+
+  meta(attrs: MetaAttributes): void {
+    let key: string | undefined;
+    if (attrs.name) {
+      key = `name:${attrs.name}`;
+    } else if (attrs.property) {
+      key = `property:${attrs.property}`;
+    }
+
+    if (!key) {
+      return;
+    }
+    this.metas.set(key, attrs);
+  }
+
+  metaName(name: string, content: string): void {
+    this.meta({ name, content });
+  }
+
+  metaProperty(property: string, content: string): void {
+    this.meta({ property, content });
+  }
+
+  render(): string {
+    const tags: string[] = [];
+
+    if (this.canonicalUrl) {
+      tags.push(`<link rel="canonical" href="${this.canonicalUrl}" />`);
+    }
+
+    if (this.titleText) {
+      tags.push(`<title>${this.titleText}</title>`);
+    }
+
+    this.metas.forEach((attrs) => {
+      if (attrs.name) {
+        tags.push(`<meta name="${attrs.name}" content="${attrs.content}" />`);
+      } else if (attrs.property) {
+        tags.push(`<meta property="${attrs.property}" content="${attrs.content}" />`);
+      }
+    });
+
+    return tags.join('\n');
+  }
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,17 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import { di } from '../../di';
+import { TYPES } from '../../types';
+import HeadManager from '../head/HeadManager';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.get('/preview/head', (req, resp) => {
+      const headManager = di.get<HeadManager>(TYPES.HeadManager);
+      resp.setHeader('Content-Type', 'text/html');
+      resp.send(headManager.render());
+    });
   }
 }

--- a/src/templates/_common/templates/header/basic.ejs
+++ b/src/templates/_common/templates/header/basic.ejs
@@ -3,12 +3,15 @@ const { di } = require('../../../../di');
 const { TYPES } = require('../../../../types');
 
 /** @type {IApplication} */
-const app = di.get(TYPES.Application)
+const app = di.get(TYPES.Application);
+const headManager = di.get(TYPES.HeadManager);
 
-const { config, template } = app;
+const { config, template, url } = app;
+
+headManager.canonical(url);
+headManager.title(`${config.data.first_name} ${config.data.last_name}`);
+headManager.metaName('generator', 'GPortfolio');
+headManager.metaName('author', template.info.author);
+headManager.metaName('description', `Portfolio by ${config.data.first_name} ${config.data.last_name}`);
 %>
-
 <meta charset="utf-8">
-<meta name="generator" content="GPortfolio">
-<meta name="author" content="<%= template.info.author %>">
-<title><%= `${config.data.first_name} ${config.data.last_name}` %></title>

--- a/src/templates/_common/templates/header/full.ejs
+++ b/src/templates/_common/templates/header/full.ejs
@@ -1,2 +1,12 @@
+<%
+const { di } = require('../../../../di');
+const { TYPES } = require('../../../../types');
+const headManager = di.get(TYPES.HeadManager);
+
+headManager.reset();
+%>
 <%= require('./basic.ejs')() %>
-<%= require('./opg.ejs')() %>
+<%
+require('./opg.ejs')();
+%>
+<%= headManager.render() %>

--- a/src/templates/_common/templates/header/opg.ejs
+++ b/src/templates/_common/templates/header/opg.ejs
@@ -2,23 +2,24 @@
 const { resolveFile } = require('../../scripts/template');
 const { di } = require('../../../../di');
 const { TYPES } = require('../../../../types');
+const headManager = di.get(TYPES.HeadManager);
 
 /** @type {IApplication} */
 const app = di.get(TYPES.Application);
 
 const { config, url } = app;
-%>
 
-<meta property="og:title" content="Portfolio by <%= `${config.data.first_name} ${config.data.last_name}` %>" />
-<meta property="og:type" content="profile" />
-<meta property="og:image" content="<%= resolveFile(config.data.avatar) %>" />
-<meta property="og:url" content="<%= url %>" />
-<% if (config.data.bio) { %><meta property="og:description" content="<%= config.data.bio %>" /><% } %>
-<% if (config.global.locale) { %><meta property="og:locale" content="<%= config.global.locale %>" /><% } %>
-<% if (config.data.first_name) { %><meta property="profile:first_name" content="<%= config.data.first_name %>"><% } %>
-<% if (config.data.last_name) { %><meta property="profile:last_name" content="<%= config.data.last_name %>"><% } %>
-<% if (config.data.login) { %><meta property="profile:username" content="<%= config.data.login %>" /><% } %>
-<% if (config.data.gender) { %><meta property="profile:gender" content="<%= config.data.gender %>"><% } %>
-<% for (let [property, content] of Object.entries(config.global.opg)) { %>
-    <meta property="<%= property %>" content="<%= content %>" />
-<% } %>
+headManager.metaProperty('og:title', `Portfolio by ${config.data.first_name} ${config.data.last_name}`);
+headManager.metaProperty('og:type', 'profile');
+headManager.metaProperty('og:image', resolveFile(config.data.avatar));
+headManager.metaProperty('og:url', url);
+if (config.data.bio) headManager.metaProperty('og:description', config.data.bio);
+if (config.global.locale) headManager.metaProperty('og:locale', config.global.locale);
+if (config.data.first_name) headManager.metaProperty('profile:first_name', config.data.first_name);
+if (config.data.last_name) headManager.metaProperty('profile:last_name', config.data.last_name);
+if (config.data.login) headManager.metaProperty('profile:username', config.data.login);
+if (config.data.gender) headManager.metaProperty('profile:gender', config.data.gender);
+for (let [property, content] of Object.entries(config.global.opg)) {
+    headManager.metaProperty(property, content);
+}
+%>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ const TYPES = {
   FilterCompareItems: Symbol.for('filter.compare.items'),
   Services: Symbol.for('services'),
   Templates: Symbol.for('templates'),
+  HeadManager: Symbol.for('head.manager'),
 
   ...githubService,
 };

--- a/tests/modules/HeadManager.test.ts
+++ b/tests/modules/HeadManager.test.ts
@@ -1,0 +1,31 @@
+import HeadManager from '../../src/modules/head/HeadManager';
+
+describe('HeadManager', () => {
+  it('emits canonical, meta and open graph tags without duplicates', () => {
+    const manager = new HeadManager();
+
+    manager.canonical('https://example.com');
+    manager.canonical('https://override.com');
+
+    manager.title('First Title');
+    manager.title('Final Title');
+
+    manager.metaName('description', 'desc1');
+    manager.metaName('description', 'desc2');
+
+    manager.metaProperty('og:title', 'OG1');
+    manager.metaProperty('og:title', 'OG2');
+
+    const out = manager.render();
+
+    expect(out.match(/<link rel="canonical"/g)?.length).toBe(1);
+    expect(out.match(/<title>/g)?.length).toBe(1);
+    expect(out.match(/<meta name="description"/g)?.length).toBe(1);
+    expect(out.match(/<meta property="og:title"/g)?.length).toBe(1);
+
+    expect(out).toContain('https://override.com');
+    expect(out).toContain('Final Title');
+    expect(out).toContain('desc2');
+    expect(out).toContain('OG2');
+  });
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -128,7 +128,6 @@ export default (env: any, argv: { mode: string; }): Configuration => {
         inject: 'head',
         chunks: ['main'],
         meta: {
-          description: `Portfolio by ${config.data.first_name} ${config.data.last_name}`,
           robots: 'index, follow',
           viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no',
           ...config.global.meta,


### PR DESCRIPTION
## Summary
- implement `HeadManager` to emit canonical, meta, and Open Graph tags with deduplication
- update templates to use head manager and avoid duplicate title/description tags
- expose `/preview/head` route to view final head output in development

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd4920b08328ab7eb19e87a51826