### PR TITLE
refactor: improve animation performance

### DIFF
--- a/src/modules/filter/Filter.ts
+++ b/src/modules/filter/Filter.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from 'inversify';
 import IFilterItem from './interfaces/IFilterItem';
 import FilterCompare from './FilterCompare';
 import ObjectUtils from '../../utils/ObjectUtils';
+import { markStart, markEnd } from '../../utils/performance';
 
 @injectable()
 export default class Filter {
@@ -17,11 +18,14 @@ export default class Filter {
       return arr;
     }
 
-    return arr.filter((item) => groupFilters.some((group) => group.every((filter) => {
+    markStart('filter-handle');
+    const result = arr.filter((item) => groupFilters.some((group) => group.every((filter) => {
       const values = ObjectUtils.deepKeyFromString(item, filter.attr, separator);
       const res = this.filterCompare.compare(filter.values, values, filter.options || {});
 
       return (res || filter.revert) && (!res || !filter.revert);
     })));
+    markEnd('filter-handle');
+    return result;
   }
 }

--- a/src/templates/default/styles/header.scss
+++ b/src/templates/default/styles/header.scss
@@ -66,11 +66,11 @@
         padding: 9px;
         margin: 0 7px;
         color: #fff;
-        transition: .2s;
+        transition: transform .2s, opacity .2s;
         min-width: 35px;
         &:hover {
-          background: rgba(0, 0, 0, .5);
-          border-radius: 10px;
+          transform: scale(1.1);
+          opacity: .85;
         }
       }
       svg {

--- a/src/templates/default/styles/helper.scss
+++ b/src/templates/default/styles/helper.scss
@@ -69,11 +69,8 @@
   text-transform: uppercase;
   background-color: transparent;
   cursor: pointer;
-  transition: .1s ease-in-out;
-  transition-property: color,background-color,border-color;
+  transition: opacity .1s ease-in-out;
   &:hover {
-    background-color: transparent;
-    color: #333;
-    border-color: #b2b2b2;
+    opacity: .8;
   }
 }

--- a/src/templates/default/styles/repositories.scss
+++ b/src/templates/default/styles/repositories.scss
@@ -21,7 +21,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 15px 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, .12), 0 1px 2px rgba(0, 0, 0, .24);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
+  transition: transform .2s, opacity .2s;
   &__name {
     color: #474a73;
     font-size: 1rem;
@@ -57,14 +58,8 @@
       }
     }
   }
-  &__name,
-  &__footer {
-    transition: .2s color;
-  }
   &:hover {
-    .repository__name,
-    .repository__footer {
-      color: #000;
-    }
+    transform: translateY(-2px);
+    opacity: .95;
   }
 }

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,0 +1,21 @@
+const perf = (typeof performance === 'undefined'
+  ? require('perf_hooks').performance
+  : performance);
+
+export function markStart(name: string): void {
+  perf.mark(`${name}-start`);
+}
+
+export function markEnd(name: string): number {
+  const endMark = `${name}-end`;
+  perf.mark(endMark);
+  const measureName = `${name}-measure`;
+  perf.measure(measureName, `${name}-start`, endMark);
+  const [measure] = perf.getEntriesByName(measureName);
+  perf.clearMarks(`${name}-start`);
+  perf.clearMarks(endMark);
+  perf.clearMeasures(measureName);
+  return measure?.duration ?? 0;
+}
+
+export default { markStart, markEnd };

--- a/tests/utils/PerformanceUtils.test.ts
+++ b/tests/utils/PerformanceUtils.test.ts
@@ -1,0 +1,9 @@
+import { markStart, markEnd } from '../../src/utils/performance';
+
+describe('performance utils', () => {
+  it('measures duration', () => {
+    markStart('test');
+    const duration = markEnd('test');
+    expect(duration).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- shift hover effects to transform/opacity for smoother animations
- lighten repository box-shadow and add performance marks to filter handling
- introduce reusable performance utilities with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd4b6688832896e7f811c567718c