### PR TITLE
feat: add validated env parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.5"
+  },
+  "dependencies": {
+    "zod": "3.22.2"
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const serverSchema = z.object({
+  GITHUB_TOKEN: z.string().min(1, 'GITHUB_TOKEN is required'),
+});
+
+const clientSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
+  PUBLIC_URL: z.string().url().optional(),
+});
+
+const envSchema = serverSchema.merge(clientSchema);
+
+const _env = envSchema.safeParse(process.env);
+if (!_env.success) {
+  console.error('Invalid environment variables', _env.error.flatten().fieldErrors);
+  throw new Error('Invalid environment variables');
+}
+
+const envData = _env.data;
+
+export const env = {
+  NODE_ENV: envData.NODE_ENV ?? 'development',
+  PUBLIC_URL: envData.PUBLIC_URL ?? 'http://localhost:3000',
+  GITHUB_TOKEN: envData.GITHUB_TOKEN,
+};
+
+export const envMap = {
+  server: { GITHUB_TOKEN: env.GITHUB_TOKEN },
+  client: { NODE_ENV: env.NODE_ENV, PUBLIC_URL: env.PUBLIC_URL },
+};

--- a/src/services/github/helper/utils.ts
+++ b/src/services/github/helper/utils.ts
@@ -4,6 +4,7 @@ import { di } from '../../../di';
 import IApplication from '../../../interfaces/IApplication';
 import { TYPES } from '../../../types';
 import GithubPublicFetcher from '../fetcher/GithubPublicFetcher';
+import { envMap } from '../../../env';
 
 // eslint-disable-next-line import/prefer-default-export
 export function parseGithubFetcher(): IGithubFetcher | undefined {
@@ -13,8 +14,8 @@ export function parseGithubFetcher(): IGithubFetcher | undefined {
     return new GithubPrivateFetcher(args[0]);
   }
 
-  if (process.env.GITHUB_TOKEN) {
-    return new GithubPrivateFetcher(process.env.GITHUB_TOKEN);
+  if (envMap.server.GITHUB_TOKEN) {
+    return new GithubPrivateFetcher(envMap.server.GITHUB_TOKEN);
   }
 
   const { github } = di.get<IApplication>(TYPES.Application).config.services;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,12 +7,13 @@ import path from 'path';
 import WebpackPwaManifest from 'webpack-pwa-manifest';
 import { GenerateSW } from 'workbox-webpack-plugin';
 import fs from 'fs';
-import { WebpackPluginInstance, Configuration } from 'webpack';
+import webpack, { WebpackPluginInstance, Configuration } from 'webpack';
 import { Configuration as DevServerConfiguration } from 'webpack-dev-server';
 import { di } from './src/di';
 import Server from './src/modules/server/Server';
 import IApplication from './src/interfaces/IApplication';
 import TYPES from './src/types';
+import { envMap } from './src/env';
 
 function resolvePage(name: string, file: string) {
   return `./src/pages/${name}/${file}`;
@@ -117,6 +118,9 @@ export default (env: any, argv: { mode: string; }): Configuration => {
       publicPath: '/',
     },
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env': JSON.stringify(envMap.client),
+      }),
       new CopyWebpackPlugin({
         patterns: [
           { from: 'public/export/', to: 'public/' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9528,3 +9528,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@3.22.2:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
## Summary
- validate process.env with zod and expose client/server maps
- inject client env vars via webpack and consume token from map

## Testing
- `NODE_ENV=production npx -y yarn@1 run build` *(fails: Invalid environment variables { GITHUB_TOKEN: ['Required'] })*
- `NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production GITHUB_TOKEN=dummy npx -y yarn@1 run build` *(fails: Node Sass does not yet support your current environment)*
- `GITHUB_TOKEN=dummy npx -y yarn@1 test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd482ca88328a0df16c5e4fb8f7d