### PR TITLE
feat: add searchable index with hydration

### DIFF
--- a/src/modules/search/SearchIndex.ts
+++ b/src/modules/search/SearchIndex.ts
@@ -1,0 +1,80 @@
+export interface ISearchDoc {
+  id: number;
+  text: string;
+  facets?: string[];
+}
+
+export type FetchFn = (url: string) => Promise<ISearchDoc[]>;
+
+export default class SearchIndex {
+  private index: ISearchDoc[] = [];
+
+  private storage: Storage;
+
+  private fetchFn: FetchFn;
+
+  private version: string;
+
+  private readonly storageKey = 'search-index';
+
+  private readonly versionKey = 'search-index-version';
+
+  constructor(
+    compact: ISearchDoc[],
+    version: string,
+    fetchFn: FetchFn,
+    storage: Storage,
+  ) {
+    this.storage = storage;
+    this.fetchFn = fetchFn;
+    this.version = version;
+    this.init(compact);
+  }
+
+  private init(compact: ISearchDoc[]) {
+    const storedVersion = this.storage.getItem(this.versionKey);
+    if (storedVersion !== this.version) {
+      this.storage.removeItem(this.storageKey);
+      this.storage.setItem(this.versionKey, this.version);
+    }
+    const cached = this.storage.getItem(this.storageKey);
+    if (cached) {
+      this.index = JSON.parse(cached);
+    } else {
+      this.index = compact.slice();
+      this.storage.setItem(this.storageKey, JSON.stringify(this.index));
+    }
+  }
+
+  public scheduleHydration(url: string): void {
+    const hydrate = () => { this.hydrate(url); };
+    if (typeof (global as any).requestIdleCallback === 'function') {
+      (global as any).requestIdleCallback(hydrate);
+    } else {
+      setTimeout(hydrate, 0);
+    }
+  }
+
+  public async hydrate(url: string): Promise<void> {
+    const remote = await this.fetchFn(url);
+    const map = new Map(this.index.map((d) => [d.id, d]));
+    remote.forEach((doc) => {
+      const existing = map.get(doc.id);
+      if (existing) {
+        Object.assign(existing, doc);
+      } else {
+        this.index.push(doc);
+      }
+    });
+    this.storage.setItem(this.storageKey, JSON.stringify(this.index));
+  }
+
+  public search(term: string): ISearchDoc[] {
+    const lower = term.toLowerCase();
+    return this.index.filter((d) => d.text.toLowerCase().includes(lower));
+  }
+
+  public getIndex(): ISearchDoc[] {
+    return this.index;
+  }
+}

--- a/src/modules/search/compact.json
+++ b/src/modules/search/compact.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "text": "local hello" },
+  { "id": 2, "text": "local data" }
+]

--- a/tests/data/remote-facets.json
+++ b/tests/data/remote-facets.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "facets": ["greeting"] },
+  { "id": 3, "text": "remote hydrated data", "facets": ["remote"] }
+]

--- a/tests/modules/SearchIndex.test.ts
+++ b/tests/modules/SearchIndex.test.ts
@@ -1,0 +1,42 @@
+import SearchIndex, { ISearchDoc } from '../../src/modules/search/SearchIndex';
+
+class MemoryStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  length = 0;
+
+  clear(): void { this.store = {}; this.length = 0; }
+  getItem(key: string): string | null { return this.store[key] ?? null; }
+  key(index: number): string | null { return Object.keys(this.store)[index] ?? null; }
+  removeItem(key: string): void { delete this.store[key]; this.length = Object.keys(this.store).length; }
+  setItem(key: string, value: string): void { this.store[key] = String(value); this.length = Object.keys(this.store).length; }
+}
+
+const compact: ISearchDoc[] = require('../../src/modules/search/compact.json');
+const remote: ISearchDoc[] = require('../data/remote-facets.json');
+
+const fetchFn = async () => remote;
+
+describe('SearchIndex', () => {
+  it('warms local index and hydrates later', async () => {
+    const storage = new MemoryStorage();
+    const index = new SearchIndex(compact, 'v1', fetchFn, storage);
+
+    expect(index.search('local').length).toBe(2);
+    expect(index.search('remote').length).toBe(0);
+
+    await index.hydrate('remote-url');
+
+    expect(index.search('remote').length).toBe(1);
+  });
+
+  it('clears cache on version change', async () => {
+    const storage = new MemoryStorage();
+    const indexV1 = new SearchIndex(compact, 'v1', fetchFn, storage);
+    await indexV1.hydrate('remote-url');
+    expect(indexV1.search('remote').length).toBe(1);
+
+    const indexV2 = new SearchIndex(compact, 'v2', fetchFn, storage);
+    expect(indexV2.search('remote').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- warm search index from compact JSON and schedule background hydration
- version cached index and reset on schema changes
- test search improvement after hydration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd4d57908328a9c9e06242d4652b