### PR TITLE
feat: add diff manager with annotations and revert preview

### DIFF
--- a/src/@types/diff/index.d.ts
+++ b/src/@types/diff/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'diff' {
+  interface Change {
+    value: string;
+    added?: boolean;
+    removed?: boolean;
+  }
+
+  export function diffLines(oldStr: string, newStr: string): Change[];
+  export function createTwoFilesPatch(
+    oldFileName: string,
+    newFileName: string,
+    oldStr: string,
+    newStr: string,
+  ): string;
+}

--- a/src/modules/diff/DiffManager.ts
+++ b/src/modules/diff/DiffManager.ts
@@ -1,0 +1,82 @@
+import { createTwoFilesPatch, diffLines } from 'diff';
+
+export interface ChangeAnnotation {
+  author: string;
+  time: Date;
+  reason: string;
+}
+
+export interface SplitDiffLine {
+  left: string;
+  right: string;
+}
+
+export interface DiffResult {
+  unified: string;
+  split: SplitDiffLine[];
+}
+
+interface HistoryEntry {
+  oldContent: string;
+  newContent: string;
+  annotation: ChangeAnnotation;
+}
+
+export default class DiffManager {
+  private history: HistoryEntry[] = [];
+
+  generateDiff(
+    fileName: string,
+    oldContent: string,
+    newContent: string,
+    annotation: ChangeAnnotation,
+  ): DiffResult {
+    const result = this.createDiff(fileName, oldContent, newContent);
+    this.history.push({ oldContent, newContent, annotation });
+    return result;
+  }
+
+  previewRevert(index: number): DiffResult {
+    const entry = this.history[index];
+    if (!entry) {
+      throw new Error('Change index out of range');
+    }
+
+    return this.createDiff('revert', entry.newContent, entry.oldContent);
+  }
+
+  getHistory(): HistoryEntry[] {
+    return this.history;
+  }
+
+  private createDiff(fileName: string, oldContent: string, newContent: string): DiffResult {
+    const unified = createTwoFilesPatch(
+      `${fileName}-old`,
+      `${fileName}-new`,
+      oldContent,
+      newContent,
+    );
+
+    const parts = diffLines(oldContent, newContent);
+    const split: SplitDiffLine[] = [];
+
+    parts.forEach((part) => {
+      const lines = part.value.split('\n');
+      if (lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+
+      lines.forEach((line) => {
+        if (part.added) {
+          split.push({ left: '', right: line });
+        } else if (part.removed) {
+          split.push({ left: line, right: '' });
+        } else {
+          split.push({ left: line, right: line });
+        }
+      });
+    });
+
+    return { unified, split };
+  }
+}

--- a/tests/modules/DiffManager.test.ts
+++ b/tests/modules/DiffManager.test.ts
@@ -1,0 +1,43 @@
+import DiffManager, { ChangeAnnotation } from '../../src/modules/diff/DiffManager';
+
+describe('DiffManager', () => {
+  it('creates unified and split diffs for Markdown', () => {
+    const manager = new DiffManager();
+    const oldContent = '# Title\n\nParagraph';
+    const newContent = '# Title\n\nNew paragraph';
+    const annotation: ChangeAnnotation = {
+      author: 'Alice',
+      time: new Date('2023-01-01T00:00:00Z'),
+      reason: 'Update paragraph',
+    };
+
+    const result = manager.generateDiff('doc.md', oldContent, newContent, annotation);
+
+    expect(result.unified).toContain('-Paragraph');
+    expect(result.unified).toContain('+New paragraph');
+
+    const removed = result.split.some((l) => l.left === 'Paragraph' && l.right === '');
+    const added = result.split.some((l) => l.left === '' && l.right === 'New paragraph');
+
+    expect(removed).toBe(true);
+    expect(added).toBe(true);
+
+    expect(manager.getHistory()[0].annotation.author).toBe('Alice');
+  });
+
+  it('previews revert for JSON changes', () => {
+    const manager = new DiffManager();
+    const oldJson = '{\n  "a": 1\n}\n';
+    const newJson = '{\n  "a": 2\n}\n';
+    manager.generateDiff('data.json', oldJson, newJson, {
+      author: 'Bob',
+      time: new Date('2023-01-02T00:00:00Z'),
+      reason: 'Change value',
+    });
+
+    const preview = manager.previewRevert(0);
+
+    expect(preview.unified).toContain('-  "a": 2');
+    expect(preview.unified).toContain('+  "a": 1');
+  });
+});


### PR DESCRIPTION
## Summary
- add DiffManager for unified and split diffs with change annotations
- support revert preview before applying changes
- cover diff manager with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd523f2883289db3fd1fbe3543ad