### PR TITLE
feat: add design token contrast checks

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!design-tokens.json

--- a/data/design-tokens.json
+++ b/data/design-tokens.json
@@ -1,0 +1,14 @@
+{
+  "pairs": [
+    {
+      "name": "textOnLight",
+      "foreground": "#0a0a0a",
+      "background": "#ffffff"
+    },
+    {
+      "name": "textOnDark",
+      "foreground": "#ffffff",
+      "background": "#1a1a1a"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "lint:tokens": "ts-node ./scripts/contrast-lint.ts",
+    "lint:tokens:fix": "ts-node ./scripts/contrast-lint.ts --fix"
   },
   "browserslist": [
     "defaults",

--- a/scripts/contrast-lint.ts
+++ b/scripts/contrast-lint.ts
@@ -1,0 +1,31 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { autoAdjust, validatePairs, ColorPair } from '../src/utils/Contrast';
+
+const tokenPath = './data/design-tokens.json';
+const raw = readFileSync(tokenPath, 'utf8');
+const data = JSON.parse(raw) as { pairs: ColorPair[] };
+
+const fix = process.argv.includes('--fix');
+let modified = false;
+
+data.pairs.forEach((pair) => {
+  if (!validatePairs([pair])) {
+    if (fix) {
+      const adjusted = autoAdjust(pair.foreground, pair.background);
+      // eslint-disable-next-line no-param-reassign
+      pair.foreground = adjusted;
+      modified = true;
+    } else {
+      console.error(`Contrast failure for ${pair.name}`);
+      process.exitCode = 1;
+    }
+  }
+});
+
+if (fix && modified) {
+  writeFileSync(tokenPath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}

--- a/src/utils/Contrast.ts
+++ b/src/utils/Contrast.ts
@@ -1,0 +1,81 @@
+export interface ColorPair {
+  name: string;
+  foreground: string;
+  background: string;
+}
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function hexToRgb(hex: string): RGB {
+  const value = hex.replace('#', '');
+  const r = parseInt(value.substring(0, 2), 16);
+  const g = parseInt(value.substring(2, 4), 16);
+  const b = parseInt(value.substring(4, 6), 16);
+  return { r, g, b };
+}
+
+function componentToHex(c: number): string {
+  const hex = Math.round(Math.min(Math.max(c, 0), 255)).toString(16);
+  return hex.length === 1 ? `0${hex}` : hex;
+}
+
+function rgbToHex({ r, g, b }: RGB): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+function luminance({ r, g, b }: RGB): number {
+  const srgb = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * srgb[0] + 0.7152 * srgb[1] + 0.0722 * srgb[2];
+}
+
+export function contrastRatio(foreground: string, background: string): number {
+  const l1 = luminance(hexToRgb(foreground));
+  const l2 = luminance(hexToRgb(background));
+  const [light, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (light + 0.05) / (dark + 0.05);
+}
+
+export function meetsAA(foreground: string, background: string, large = false): boolean {
+  const ratio = contrastRatio(foreground, background);
+  return ratio >= (large ? 3 : 4.5);
+}
+
+function adjustChannel(channel: number, amount: number): number {
+  return Math.min(255, Math.max(0, channel + amount));
+}
+
+function adjustColor(rgb: RGB, amount: number): RGB {
+  return {
+    r: adjustChannel(rgb.r, amount),
+    g: adjustChannel(rgb.g, amount),
+    b: adjustChannel(rgb.b, amount),
+  };
+}
+
+export function autoAdjust(foreground: string, background: string, large = false): string {
+  let fg = hexToRgb(foreground);
+  const bg = hexToRgb(background);
+  const target = large ? 3 : 4.5;
+  let ratio = contrastRatio(rgbToHex(fg), background);
+  let attempts = 0;
+  while (ratio < target && attempts < 100) {
+    const fgLum = luminance(fg);
+    const bgLum = luminance(bg);
+    const amount = fgLum > bgLum ? 10 : -10;
+    fg = adjustColor(fg, amount);
+    ratio = contrastRatio(rgbToHex(fg), background);
+    attempts += 1;
+  }
+  return rgbToHex(fg);
+}
+
+export function validatePairs(pairs: ColorPair[], large = false): boolean {
+  return pairs.every((p) => meetsAA(p.foreground, p.background, large));
+}

--- a/tests/utils/Contrast.test.ts
+++ b/tests/utils/Contrast.test.ts
@@ -1,0 +1,17 @@
+import { autoAdjust, meetsAA, ColorPair } from '../../src/utils/Contrast';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tokens: { pairs: ColorPair[] } = require('../../data/design-tokens.json');
+
+describe('design token contrast', () => {
+  test('tokens meet AA contrast', () => {
+    tokens.pairs.forEach((p: ColorPair) => {
+      expect(meetsAA(p.foreground, p.background)).toBe(true);
+    });
+  });
+
+  test('autoAdjust nudges color to AA', () => {
+    const adjusted = autoAdjust('#777777', '#ffffff');
+    expect(meetsAA(adjusted, '#ffffff')).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   "include": [
     "src",
     "tests",
+    "scripts"
   ],
 }


### PR DESCRIPTION
## Summary
- add design token definition file
- introduce contrast utilities with auto-adjust helper
- add token lint script and tests to enforce AA contrast ratios

## Testing
- `npm run lint:tokens`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd55dc88832896d81c3861802eb0