### PR TITLE
Add virtualized gallery with metadata redaction

### DIFF
--- a/src/modules/gallery/Lightbox.ts
+++ b/src/modules/gallery/Lightbox.ts
@@ -1,0 +1,78 @@
+export default class Lightbox {
+  private images: string[];
+
+  private index = 0;
+
+  private overlay: HTMLElement;
+
+  private img: HTMLImageElement;
+
+  constructor(images: string[]) {
+    this.images = images;
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'lightbox hidden';
+    this.img = document.createElement('img');
+    this.overlay.appendChild(this.img);
+    document.body.appendChild(this.overlay);
+    this.overlay.addEventListener('click', () => this.close());
+    window.addEventListener('keydown', (e) => this.onKeyDown(e as KeyboardEvent));
+    this.initPinchZoom();
+  }
+
+  public open(index: number): void {
+    this.index = index;
+    this.overlay.classList.remove('hidden');
+    this.show();
+    this.preload();
+  }
+
+  public close(): void {
+    this.overlay.classList.add('hidden');
+    this.img.style.transform = '';
+  }
+
+  private show(): void {
+    this.img.src = this.images[this.index];
+  }
+
+  private preload(): void {
+    [this.index - 1, this.index + 1].forEach((i) => {
+      if (i >= 0 && i < this.images.length) {
+        const image = new Image();
+        image.src = this.images[i];
+      }
+    });
+  }
+
+  private onKeyDown(e: KeyboardEvent): void {
+    if (this.overlay.classList.contains('hidden')) return;
+    if (e.key === 'ArrowRight' && this.index < this.images.length - 1) {
+      this.index += 1;
+      this.show();
+      this.preload();
+    } else if (e.key === 'ArrowLeft' && this.index > 0) {
+      this.index -= 1;
+      this.show();
+      this.preload();
+    } else if (e.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  private initPinchZoom(): void {
+    let distance = 0;
+    const onMove = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        const [a, b] = e.touches;
+        const newDistance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+        if (distance) {
+          const scale = newDistance / distance;
+          this.img.style.transform = `scale(${scale})`;
+        }
+        distance = newDistance;
+      }
+    };
+    this.overlay.addEventListener('touchmove', onMove);
+    this.overlay.addEventListener('touchend', () => { distance = 0; });
+  }
+}

--- a/src/modules/gallery/VirtualizedGrid.ts
+++ b/src/modules/gallery/VirtualizedGrid.ts
@@ -1,0 +1,136 @@
+export interface VisibleRangeOptions {
+  scrollTop: number;
+  containerHeight: number;
+  thumbHeight: number;
+  buffer: number;
+  imagesLength: number;
+  perRow: number;
+}
+
+export function calculateVisibleRange(
+  options: VisibleRangeOptions,
+): { start: number; end: number } {
+  const {
+    scrollTop, containerHeight, thumbHeight, buffer, imagesLength, perRow,
+  } = options;
+  const totalRows = Math.ceil(imagesLength / perRow);
+  const startRow = Math.max(0, Math.floor(scrollTop / thumbHeight) - buffer);
+  const endRow = Math.min(
+    totalRows,
+    Math.ceil((scrollTop + containerHeight) / thumbHeight) + buffer,
+  );
+  return { start: startRow * perRow, end: endRow * perRow };
+}
+
+export interface VirtualizedGridOptions {
+  container: HTMLElement;
+  images: string[];
+  thumbWidth: number;
+  thumbHeight: number;
+  buffer?: number;
+  onOpen?: (index: number) => void;
+}
+
+export default class VirtualizedGrid {
+  private options: Required<VirtualizedGridOptions>;
+
+  private visibleStart = 0;
+
+  private visibleEnd = 0;
+
+  private perRow: number;
+
+  constructor(options: VirtualizedGridOptions) {
+    this.options = {
+      buffer: 1,
+      ...options,
+    } as Required<VirtualizedGridOptions>;
+
+    this.perRow = Math.max(
+      1,
+      Math.floor(
+        this.options.container.clientWidth / this.options.thumbWidth,
+      ),
+    );
+    this.attachEvents();
+    this.render();
+  }
+
+  private attachEvents(): void {
+    this.options.container.addEventListener('scroll', () => this.render());
+    this.options.container.addEventListener(
+      'keydown',
+      (e) => this.onKeyDown(e as KeyboardEvent),
+    );
+  }
+
+  private onKeyDown(e: KeyboardEvent): void {
+    const { activeElement } = document;
+    if (!(activeElement instanceof HTMLElement) || !activeElement.dataset.index) return;
+    const index = Number(activeElement.dataset.index);
+    let next = index;
+    switch (e.key) {
+      case 'ArrowRight':
+        next = Math.min(index + 1, this.options.images.length - 1);
+        break;
+      case 'ArrowLeft':
+        next = Math.max(index - 1, 0);
+        break;
+      case 'ArrowDown':
+        next = Math.min(index + this.perRow, this.options.images.length - 1);
+        break;
+      case 'ArrowUp':
+        next = Math.max(index - this.perRow, 0);
+        break;
+      case 'Enter':
+        this.options.onOpen?.(index);
+        return;
+      default:
+        return;
+    }
+    const el = this.options.container.querySelector<HTMLElement>(
+      `[data-index="${next}"]`,
+    );
+    el?.focus();
+  }
+
+  private getVisibleRange(): { start: number; end: number } {
+    return calculateVisibleRange({
+      scrollTop: this.options.container.scrollTop,
+      containerHeight: this.options.container.clientHeight,
+      thumbHeight: this.options.thumbHeight,
+      buffer: this.options.buffer,
+      imagesLength: this.options.images.length,
+      perRow: this.perRow,
+    });
+  }
+
+  public render(): void {
+    const { images, container, thumbHeight } = this.options;
+    const range = this.getVisibleRange();
+    if (range.start === this.visibleStart && range.end === this.visibleEnd) return;
+    this.visibleStart = range.start;
+    this.visibleEnd = range.end;
+    container.innerHTML = '';
+    container.style.position = 'relative';
+    container.style.height = `${
+      Math.ceil(images.length / this.perRow) * thumbHeight
+    }px`;
+    const fragment = document.createDocumentFragment();
+    for (let i = range.start; i < range.end && i < images.length; i += 1) {
+      const img = document.createElement('img');
+      img.src = images[i];
+      img.dataset.index = String(i);
+      img.tabIndex = 0;
+      img.style.position = 'absolute';
+      const row = Math.floor(i / this.perRow);
+      const col = i % this.perRow;
+      img.style.top = `${row * thumbHeight}px`;
+      img.style.left = `${col * this.options.thumbWidth}px`;
+      img.width = this.options.thumbWidth;
+      img.height = thumbHeight;
+      fragment.appendChild(img);
+    }
+    container.appendChild(fragment);
+  }
+}

--- a/src/utils/exif.ts
+++ b/src/utils/exif.ts
@@ -1,0 +1,25 @@
+const GPS_FIELDS = [
+  'GPSLatitude',
+  'GPSLongitude',
+  'GPSAltitude',
+  'GPSLatitudeRef',
+  'GPSLongitudeRef',
+  'GPSAltitudeRef',
+  'GPSInfo',
+];
+
+export function redactGps<T extends Record<string, unknown>>(exif: T): T {
+  const result: Record<string, unknown> = { ...exif };
+  GPS_FIELDS.forEach((field) => {
+    if (field in result) {
+      delete result[field];
+    }
+  });
+  return result as T;
+}
+
+export async function readExif(file: Blob): Promise<Record<string, unknown>> {
+  const { default: exifr } = await import('exifr');
+  const data = await exifr.parse(file);
+  return redactGps(data);
+}

--- a/tests/modules/VirtualizedGrid.test.ts
+++ b/tests/modules/VirtualizedGrid.test.ts
@@ -1,0 +1,27 @@
+import { calculateVisibleRange } from '../../src/modules/gallery/VirtualizedGrid';
+
+describe('VirtualizedGrid', () => {
+  it('calculates visible range at top', () => {
+    const range = calculateVisibleRange({
+      scrollTop: 0,
+      containerHeight: 500,
+      thumbHeight: 100,
+      buffer: 1,
+      imagesLength: 1000,
+      perRow: 5,
+    });
+    expect(range).toStrictEqual({ start: 0, end: 30 });
+  });
+
+  it('calculates visible range in middle', () => {
+    const range = calculateVisibleRange({
+      scrollTop: 1000,
+      containerHeight: 500,
+      thumbHeight: 100,
+      buffer: 1,
+      imagesLength: 1000,
+      perRow: 5,
+    });
+    expect(range).toStrictEqual({ start: 45, end: 80 });
+  });
+});

--- a/tests/utils/exif.test.ts
+++ b/tests/utils/exif.test.ts
@@ -1,0 +1,14 @@
+import { redactGps } from '../../src/utils/exif';
+
+describe('Exif utilities', () => {
+  it('redacts GPS fields', () => {
+    const data = {
+      Model: 'Camera',
+      GPSLatitude: 1,
+      GPSLongitude: 2,
+      GPSInfo: 'info',
+    };
+    const sanitized = redactGps(data);
+    expect(sanitized).toStrictEqual({ Model: 'Camera' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement virtualized thumbnail grid with keyboard navigation
- add lightbox viewer preloading neighbours and pinch-zoom support
- parse Exif metadata while removing GPS fields

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5705a0832890667a4f1080f12a