### PR TITLE
feat: add global drop handler

### DIFF
--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,17 @@
+import GlobalDropHandler from '../../../utils/GlobalDropHandler';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });
   }
+
+  new GlobalDropHandler({
+    flows: {
+      'image/': (files) => console.log('image flow', files),
+      'text/': (files) => console.log('text flow', files),
+    },
+    invalid: (files, reason) => console.warn(reason),
+  });
 })();

--- a/src/templates/_common/styles/index.scss
+++ b/src/templates/_common/styles/index.scss
@@ -1,1 +1,5 @@
 @import "~normalize.css";
+
+[data-drop-target].drop-target--active {
+  outline: 2px dashed #409eff;
+}

--- a/src/utils/GlobalDropHandler.ts
+++ b/src/utils/GlobalDropHandler.ts
@@ -1,0 +1,88 @@
+export type DropFlow = (files: File[]) => void;
+
+export interface GlobalDropHandlerOptions {
+  flows: Record<string, DropFlow>;
+  /** Called when file type is not supported */
+  invalid?: (files: File[], reason: string) => void;
+  /** CSS selector for drop targets */
+  dropTargetSelector?: string;
+  /** CSS class applied to drop targets on drag */
+  highlightClass?: string;
+}
+
+/**
+ * GlobalDropHandler listens for drag/drop events on the whole document
+ * and routes dropped files to proper flows based on their mime type.
+ */
+export default class GlobalDropHandler {
+  private invalid: (files: File[], reason: string) => void;
+
+  private selector: string;
+
+  private highlightClass: string;
+
+  constructor(private options: GlobalDropHandlerOptions) {
+    this.invalid = options.invalid || ((files, reason) => console.error(reason, files));
+    this.selector = options.dropTargetSelector || '[data-drop-target]';
+    this.highlightClass = options.highlightClass || 'drop-target--active';
+
+    this.handleDragOver = this.handleDragOver.bind(this);
+    this.handleDragLeave = this.handleDragLeave.bind(this);
+    this.handleDrop = this.handleDrop.bind(this);
+
+    document.addEventListener('dragover', this.handleDragOver);
+    document.addEventListener('dragleave', this.handleDragLeave);
+    document.addEventListener('drop', this.handleDrop);
+  }
+
+  /** Remove listeners */
+  destroy(): void {
+    document.removeEventListener('dragover', this.handleDragOver);
+    document.removeEventListener('dragleave', this.handleDragLeave);
+    document.removeEventListener('drop', this.handleDrop);
+  }
+
+  private highlight(enable: boolean): void {
+    const targets = document.querySelectorAll<HTMLElement>(this.selector);
+    targets.forEach((el) => {
+      el.classList.toggle(this.highlightClass, enable);
+    });
+  }
+
+  private handleDragOver(e: DragEvent): void {
+    e.preventDefault();
+    this.highlight(true);
+  }
+
+  private handleDragLeave(e: DragEvent): void {
+    if (e.target === document || (e.target as HTMLElement).parentElement === null) {
+      this.highlight(false);
+    }
+  }
+
+  private handleDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.highlight(false);
+
+    const files = Array.from(e.dataTransfer?.files || []);
+    files.forEach((file) => {
+      const flow = this.resolveFlow(file);
+      if (flow) {
+        flow([file]);
+      } else {
+        this.invalid([file], `Unsupported file type: ${file.type}`);
+      }
+    });
+  }
+
+  private resolveFlow(file: File): DropFlow | undefined {
+    const entries = Object.entries(this.options.flows);
+    for (const [type, flow] of entries) {
+      if (file.type.startsWith(type)) {
+        return flow;
+      }
+    }
+    return undefined;
+  }
+}
+

--- a/tests/utils/GlobalDropHandler.test.ts
+++ b/tests/utils/GlobalDropHandler.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+import GlobalDropHandler from '../../src/utils/GlobalDropHandler';
+
+describe('GlobalDropHandler', () => {
+  let imageFlow: jest.Mock;
+  let textFlow: jest.Mock;
+  let invalid: jest.Mock;
+  let handler: GlobalDropHandler;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="target" data-drop-target></div>';
+    imageFlow = jest.fn();
+    textFlow = jest.fn();
+    invalid = jest.fn();
+    handler = new GlobalDropHandler({
+      flows: { 'image/': imageFlow, 'text/': textFlow },
+      invalid,
+    });
+  });
+
+  afterEach(() => {
+    handler.destroy();
+  });
+
+  it('highlights drop targets on dragover', () => {
+    const ev = new Event('dragover', { bubbles: true, cancelable: true });
+    document.dispatchEvent(ev);
+    expect(document.getElementById('target')?.classList.contains('drop-target--active')).toBe(true);
+  });
+
+  it('routes image file to image flow', () => {
+    const dt = { files: [new File(['a'], 'a.png', { type: 'image/png' })] } as unknown as DataTransfer;
+    const ev = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'dataTransfer', { value: dt });
+    document.dispatchEvent(ev);
+    expect(imageFlow).toHaveBeenCalledTimes(1);
+    expect(invalid).not.toHaveBeenCalled();
+  });
+
+  it('routes text file to text flow', () => {
+    const dt = { files: [new File(['txt'], 'a.txt', { type: 'text/plain' })] } as unknown as DataTransfer;
+    const ev = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'dataTransfer', { value: dt });
+    document.dispatchEvent(ev);
+    expect(textFlow).toHaveBeenCalledTimes(1);
+    expect(invalid).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported file types', () => {
+    const dt = { files: [new File(['bin'], 'a.bin', { type: 'application/octet-stream' })] } as unknown as DataTransfer;
+    const ev = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'dataTransfer', { value: dt });
+    document.dispatchEvent(ev);
+    expect(invalid).toHaveBeenCalled();
+    expect(invalid.mock.calls[0][1]).toContain('Unsupported file type');
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle drag-and-drop globally with type-based routing
- highlight valid drop targets and warn on invalid files
- add tests for drop handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5779f48328a0eee10d6cc6ce89