### PR TITLE
feat: add release channel feature flags

### DIFF
--- a/src/modules/featureFlags/FeatureFlagService.ts
+++ b/src/modules/featureFlags/FeatureFlagService.ts
@@ -1,0 +1,77 @@
+import flags, { FlagDefaults } from './flags';
+
+export type ReleaseChannel = 'preview' | 'production';
+
+type ConfirmFn = (message: string) => boolean;
+
+export default class FeatureFlagService {
+  private channel: ReleaseChannel;
+
+  private storage?: Storage;
+
+  constructor(channel: ReleaseChannel, storage?: Storage) {
+    this.channel = channel;
+    this.storage = storage;
+  }
+
+  public isEnabled(name: string): boolean {
+    const stored = this.getStoredValue(name);
+    if (stored !== null) {
+      return stored;
+    }
+    const def: FlagDefaults | undefined = flags[name];
+    return def ? def[this.channel] : false;
+  }
+
+  public toggle(name: string, confirmFn?: ConfirmFn): void {
+    const def = flags[name];
+    const isDangerous = def?.dangerous && this.channel === 'production';
+    const confirm = confirmFn ?? ((msg: string) => window.confirm(msg));
+    if (isDangerous) {
+      const first = confirm(`Enable ${name}?`);
+      if (!first) {
+        return;
+      }
+      const second = confirm('Are you sure? This may be dangerous.');
+      if (!second) {
+        return;
+      }
+    }
+    const value = !this.isEnabled(name);
+    this.storeValue(name, value);
+  }
+
+  private storageKey(name: string): string {
+    return `feature:${this.channel}:${name}`;
+  }
+
+  private getStoredValue(name: string): boolean | null {
+    const storage = this.getStorage();
+    if (!storage) {
+      return null;
+    }
+    const item = storage.getItem(this.storageKey(name));
+    if (item === null) {
+      return null;
+    }
+    return item === 'true';
+  }
+
+  private storeValue(name: string, value: boolean): void {
+    const storage = this.getStorage();
+    if (!storage) {
+      return;
+    }
+    storage.setItem(this.storageKey(name), String(value));
+  }
+
+  private getStorage(): Storage | undefined {
+    if (this.storage) {
+      return this.storage;
+    }
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+    return undefined;
+  }
+}

--- a/src/modules/featureFlags/flags.ts
+++ b/src/modules/featureFlags/flags.ts
@@ -1,0 +1,11 @@
+export interface FlagDefaults {
+  preview: boolean;
+  production: boolean;
+  dangerous?: boolean;
+}
+
+const flags: Record<string, FlagDefaults> = {
+  sample: { preview: true, production: false, dangerous: true },
+};
+
+export default flags;

--- a/src/modules/featureFlags/index.ts
+++ b/src/modules/featureFlags/index.ts
@@ -1,0 +1,4 @@
+export { default as FeatureFlagService } from './FeatureFlagService';
+export type { ReleaseChannel } from './FeatureFlagService';
+export { default as flags } from './flags';
+export type { FlagDefaults } from './flags';

--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -25,6 +25,7 @@
     </style>
 </head>
 <body>
+<div id="release-channel-badge"></div>
 <!--<section>-->
 <!--    <div class="section&#45;&#45;name">-->
 <!--        Global-->

--- a/src/pages/config/index.scss
+++ b/src/pages/config/index.scss
@@ -1,1 +1,12 @@
 @import "styles/global";
+
+#release-channel-badge {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: var(--secondary);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,21 @@
+import { FeatureFlagService, flags, ReleaseChannel } from '../../modules/featureFlags';
+
 (() => {
-  console.log('dev');
+  const channel: ReleaseChannel = (process.env.RELEASE_CHANNEL === 'preview') ? 'preview' : 'production';
+  const service = new FeatureFlagService(channel);
+
+  const badge = document.getElementById('release-channel-badge');
+  if (badge) {
+    badge.textContent = channel.toUpperCase();
+  }
+
+  Object.keys(flags).forEach((name) => {
+    const button = document.createElement('button');
+    button.textContent = `${name}: ${service.isEnabled(name) ? 'on' : 'off'}`;
+    button.addEventListener('click', () => {
+      service.toggle(name);
+      button.textContent = `${name}: ${service.isEnabled(name) ? 'on' : 'off'}`;
+    });
+    document.body.appendChild(button);
+  });
 })();

--- a/tests/modules/FeatureFlagService.test.ts
+++ b/tests/modules/FeatureFlagService.test.ts
@@ -1,0 +1,37 @@
+import { FeatureFlagService } from '../../src/modules/featureFlags';
+
+describe('FeatureFlagService', () => {
+  it('uses channel defaults', () => {
+    const preview = new FeatureFlagService('preview');
+    const prod = new FeatureFlagService('production');
+    expect(preview.isEnabled('sample')).toBe(true);
+    expect(prod.isEnabled('sample')).toBe(false);
+  });
+
+  it('stores values per channel', () => {
+    const storage: Storage = {
+      data: {} as Record<string, string>,
+      getItem(key: string) { return (this.data as any)[key] ?? null; },
+      setItem(key: string, value: string) { (this.data as any)[key] = value; },
+      removeItem() {},
+      clear() {},
+      key() { return null; },
+      length: 0,
+    } as any;
+    const preview = new FeatureFlagService('preview', storage);
+    preview.toggle('sample');
+    expect(storage.getItem('feature:preview:sample')).not.toBeNull();
+    expect(storage.getItem('feature:production:sample')).toBeNull();
+  });
+
+  it('requires two confirmations for dangerous production toggles', () => {
+    const prod = new FeatureFlagService('production');
+    const calls: string[] = [];
+    const confirmFn = (msg: string) => {
+      calls.push(msg);
+      return true;
+    };
+    prod.toggle('sample', confirmFn);
+    expect(calls.length).toBe(2);
+  });
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import WebpackPwaManifest from 'webpack-pwa-manifest';
 import { GenerateSW } from 'workbox-webpack-plugin';
 import fs from 'fs';
-import { WebpackPluginInstance, Configuration } from 'webpack';
+import webpack, { WebpackPluginInstance, Configuration } from 'webpack';
 import { Configuration as DevServerConfiguration } from 'webpack-dev-server';
 import { di } from './src/di';
 import Server from './src/modules/server/Server';
@@ -150,6 +150,9 @@ export default (env: any, argv: { mode: string; }): Configuration => {
       new MiniCssExtractPlugin({
         chunkFilename: 'static/css/[name].[fullhash].css',
         filename: 'static/[name].[fullhash].css',
+      }),
+      new webpack.DefinePlugin({
+        'process.env.RELEASE_CHANNEL': JSON.stringify(process.env.RELEASE_CHANNEL || 'production'),
       }),
     ] as WebpackPluginInstance[],
     resolve: {


### PR DESCRIPTION
## Summary
- add feature flag service with per-channel defaults
- show release channel badge in config page
- inject release channel env variable via webpack

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5917d88328a7153b6bff58755c