### PR TITLE
feat: add freshness badges with refresh option

### DIFF
--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -37,6 +37,9 @@ function generateRepositoriesHtml(repositories) {
             <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-svg="git-fork"><circle fill="none" stroke="#000" stroke-width="1.2" cx="5.79" cy="2.79" r="1.79"></circle><circle fill="none" stroke="#000" stroke-width="1.2" cx="14.19" cy="2.79" r="1.79"></circle><circle fill="none" stroke="#000" stroke-width="1.2" cx="10.03" cy="16.79" r="1.79"></circle><path fill="none" stroke="#000" stroke-width="2" d="M5.79,4.57 L5.79,6.56 C5.79,9.19 10.03,10.22 10.03,13.31 C10.03,14.86 10.04,14.55 10.04,14.55 C10.04,14.37 10.04,14.86 10.04,13.31 C10.04,10.22 14.2,9.19 14.2,6.56 L14.2,4.57"></path></svg>
             <span>${repositories[i].forks_count}</span>
           </div>
+          <div class="repository__footer__updated" data-time="${repositories[i].pushed_at}">
+            <span class="badge">Updated <span class="relative-time"></span></span>
+          </div>
         </div>
       </a>`;
   }
@@ -89,6 +92,9 @@ function generateRepositoriesHtml(repositories) {
             <span>Repositories</span>
           </span>
         </h2>
+        <div class="text--center">
+          <div id="github-refresh" class="btn-more">Refresh</div>
+        </div>
         <div class="repositories">
           <%= generateRepositoriesHtml(canShowMoreRepositories ? repositories.slice(0, repositoriesMore) : repositories) %>
         </div>
@@ -109,8 +115,8 @@ function generateRepositoriesHtml(repositories) {
     month: '2-digit'
   }) %></span>
 </footer>
-
-<% if (canShowMoreRepositories) {%>
+<script type="text/javascript"><%= generateRepositoriesHtml.toString() %></script>
+<% if (canShowMoreRepositories) { %>
 <script type="text/javascript">
 var repositories = <%= JSON.stringify(repositories.splice(repositoriesMore)) %>;
 
@@ -126,6 +132,7 @@ window.addEventListener('DOMContentLoaded', function () {
     }
 
     githubRepositories.append(...nodes);
+    if (window.updateBadges) { window.updateBadges(); }
   });
 });
 
@@ -134,9 +141,9 @@ function htmlToElements(html) {
   template.innerHTML = html;
   return template.content.childNodes;
 }
-
-<%= generateRepositoriesHtml.toString() %>
 </script>
 <% } %>
+
+<script>window.GPORTFOLIO_GITHUB_LOGIN = '<%= config.data.login %>';</script>
 </body>
 </html>

--- a/src/templates/default/index.ts
+++ b/src/templates/default/index.ts
@@ -1,1 +1,2 @@
 import '../_common/scripts';
+import './scripts/freshness';

--- a/src/templates/default/scripts/freshness.ts
+++ b/src/templates/default/scripts/freshness.ts
@@ -1,0 +1,64 @@
+import DateUtils from '../../../utils/DateUtils';
+
+declare global {
+  interface Window {
+    GPORTFOLIO_GITHUB_LOGIN?: string;
+    updateBadges?: () => void;
+    generateRepositoriesHtml?: (repos: any[]) => string;
+  }
+}
+
+const STALE_THRESHOLD = DateUtils.DEFAULT_STALE_THRESHOLD;
+
+function updateBadges(): void {
+  const nodes = document.querySelectorAll<HTMLElement>('.repository__footer__updated');
+  nodes.forEach((el) => {
+    const dataTime = el.getAttribute('data-time');
+    if (!dataTime) return;
+    const date = new Date(dataTime);
+    const relative = DateUtils.relativeTime(date);
+    const absolute = date.toLocaleString();
+    const span = el.querySelector<HTMLElement>('.relative-time');
+    if (span) {
+      span.textContent = relative;
+    }
+    el.setAttribute('title', absolute);
+    if (DateUtils.isStale(date, STALE_THRESHOLD)) {
+      el.classList.add('stale');
+    } else {
+      el.classList.remove('stale');
+    }
+  });
+}
+
+function wireRefresh(): void {
+  const login = window.GPORTFOLIO_GITHUB_LOGIN;
+  const button = document.getElementById('github-refresh');
+  if (!login || !button) return;
+  button.addEventListener('click', async () => {
+    button.setAttribute('disabled', 'disabled');
+    try {
+      const response = await fetch(`https://api.github.com/users/${login}/repos?sort=updated`);
+      if (!response.ok) return;
+      const data = await response.json();
+      const container = document.querySelector('.repositories');
+      if (container && window.generateRepositoriesHtml) {
+        container.innerHTML = window.generateRepositoriesHtml(data);
+        const moreBtn = document.getElementById('github-more');
+        if (moreBtn && moreBtn.parentNode && moreBtn.parentNode.parentNode) {
+          moreBtn.parentNode.parentNode.removeChild(moreBtn.parentNode);
+        }
+        updateBadges();
+      }
+    } finally {
+      button.removeAttribute('disabled');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateBadges();
+  wireRefresh();
+});
+
+window.updateBadges = updateBadges;

--- a/src/templates/default/styles/helper.scss
+++ b/src/templates/default/styles/helper.scss
@@ -77,3 +77,11 @@
     border-color: #b2b2b2;
   }
 }
+
+.badge {
+  display: inline-block;
+  padding: 2px 4px;
+  background-color: #eee;
+  border-radius: 3px;
+  font-size: .75rem;
+}

--- a/src/templates/default/styles/repositories.scss
+++ b/src/templates/default/styles/repositories.scss
@@ -68,3 +68,8 @@
     }
   }
 }
+
+.repository__footer__updated.stale .badge {
+  background-color: #ffecec;
+  color: #c00;
+}

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -1,0 +1,37 @@
+export default class DateUtils {
+  static readonly DEFAULT_STALE_THRESHOLD = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+  static relativeTime(date: Date, now: Date = new Date()): string {
+    const diff = now.getTime() - date.getTime();
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) {
+      return `${seconds} second${seconds !== 1 ? 's' : ''} ago`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+      return `${hours} hour${hours !== 1 ? 's' : ''} ago`;
+    }
+    const days = Math.floor(hours / 24);
+    if (days < 30) {
+      return `${days} day${days !== 1 ? 's' : ''} ago`;
+    }
+    const months = Math.floor(days / 30);
+    if (months < 12) {
+      return `${months} month${months !== 1 ? 's' : ''} ago`;
+    }
+    const years = Math.floor(months / 12);
+    return `${years} year${years !== 1 ? 's' : ''} ago`;
+  }
+
+  static isStale(
+    date: Date,
+    thresholdMs: number = DateUtils.DEFAULT_STALE_THRESHOLD,
+    now: Date = new Date(),
+  ): boolean {
+    return now.getTime() - date.getTime() > thresholdMs;
+  }
+}

--- a/tests/utils/DateUtils.test.ts
+++ b/tests/utils/DateUtils.test.ts
@@ -1,0 +1,16 @@
+import DateUtils from '../../src/utils/DateUtils';
+
+describe('DateUtils', () => {
+  it('returns relative time', () => {
+    const now = new Date('2020-01-02T00:00:00Z');
+    const from = new Date('2020-01-01T00:00:00Z');
+    expect(DateUtils.relativeTime(from, now)).toBe('1 day ago');
+  });
+
+  it('detects staleness based on threshold', () => {
+    const now = new Date('2020-01-02T00:00:00Z');
+    const from = new Date('2020-01-01T00:00:00Z');
+    expect(DateUtils.isStale(from, 1000 * 60 * 60 * 12, now)).toBe(true);
+    expect(DateUtils.isStale(from, 1000 * 60 * 60 * 24 * 3, now)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- show last update timestamps and stale badges for repositories
- add refresh control to reload repositories
- expose DateUtils helper for relative time and staleness

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5a218083288fbdfc3b94af4446