### PR TITLE
feat: sanitize clipboard pastes and support plain text shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-typescript": "^7.13.0",
     "@types/copy-webpack-plugin": "^8.0.0",
+    "@types/dompurify": "^3.2.0",
     "@types/jest": "^26.0.23",
     "@types/mini-css-extract-plugin": "^1.4.3",
     "@types/shelljs": "^0.8.8",
@@ -87,5 +88,8 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.5"
+  },
+  "dependencies": {
+    "dompurify": "^3.2.6"
   }
 }

--- a/src/utils/ClipboardUtils.ts
+++ b/src/utils/ClipboardUtils.ts
@@ -1,0 +1,92 @@
+import createDOMPurify from 'dompurify';
+
+const DOMPurify = createDOMPurify(window as any);
+
+export interface PasteHandlerOptions {
+  /**
+   * Callback to upload pasted images. Should return URL of uploaded image.
+   */
+  uploadImage?: (file: File) => Promise<string> | string | void;
+  /**
+   * Paste clipboard data as plain text.
+   */
+  plainText?: boolean;
+}
+
+export default class ClipboardUtils {
+  /**
+   * Sanitize HTML content to prevent XSS.
+   */
+  static sanitizeHtml(html: string): string {
+    return DOMPurify.sanitize(html);
+  }
+
+  /**
+   * Handle paste event, sanitizing HTML and uploading images automatically.
+   */
+  static async handlePaste(
+    event: ClipboardEvent,
+    options: PasteHandlerOptions = {},
+  ): Promise<void> {
+    const { uploadImage, plainText } = options;
+    const data = event.clipboardData;
+    if (!data) return;
+
+    if (plainText) {
+      event.preventDefault();
+      const text = data.getData('text/plain');
+      document.execCommand('insertText', false, text);
+      return;
+    }
+
+    // Convert pasted images to uploads
+    let imageFile: File | null = null;
+    for (let i = 0; i < data.items.length; i += 1) {
+      const item = data.items[i];
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        imageFile = item.getAsFile();
+        break;
+      }
+    }
+    if (imageFile && uploadImage) {
+      event.preventDefault();
+      const result = await uploadImage(imageFile);
+      if (result) {
+        document.execCommand('insertImage', false, result);
+      }
+      return;
+    }
+
+    const html = data.getData('text/html');
+    if (html) {
+      event.preventDefault();
+      const sanitized = ClipboardUtils.sanitizeHtml(html);
+      document.execCommand('insertHTML', false, sanitized);
+      return;
+    }
+
+    const text = data.getData('text/plain');
+    if (text) {
+      event.preventDefault();
+      document.execCommand('insertText', false, text);
+    }
+  }
+
+  /**
+   * Attach listeners to element to enable Ctrl+Shift+V plain text paste.
+   */
+  static enablePlainTextShortcut(element: HTMLElement, options: Omit<PasteHandlerOptions, 'plainText'> = {}): void {
+    let forcePlain = false;
+    element.addEventListener('keydown', (e) => {
+      const meta = e.ctrlKey || e.metaKey;
+      if (meta && e.shiftKey && e.key.toLowerCase() === 'v') {
+        forcePlain = true;
+      }
+    });
+
+    element.addEventListener('paste', (e) => {
+      ClipboardUtils.handlePaste(e, { ...options, plainText: forcePlain });
+      forcePlain = false;
+    });
+  }
+}

--- a/tests/utils/ClipboardUtils.test.ts
+++ b/tests/utils/ClipboardUtils.test.ts
@@ -1,0 +1,22 @@
+// @ts-ignore No type definitions needed for tests
+import { JSDOM } from 'jsdom';
+
+const { window } = new JSDOM('');
+(global as any).window = window;
+(global as any).document = window.document;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ClipboardUtils = require('../../src/utils/ClipboardUtils').default;
+
+describe('ClipboardUtils', () => {
+  describe('sanitizeHtml', () => {
+    it('removes script tags', () => {
+      const dirty = '<div><script>alert(1)</script><b>Hi</b></div>';
+      expect(ClipboardUtils.sanitizeHtml(dirty)).toBe('<div><b>Hi</b></div>');
+    });
+
+    it('strips event handlers', () => {
+      const dirty = '<img src="x" onerror="alert(1)" />';
+      expect(ClipboardUtils.sanitizeHtml(dirty)).toBe('<img src="x">');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,6 +1633,13 @@
     tapable "^2.0.0"
     webpack "^5.1.0"
 
+"@types/dompurify@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.2.0.tgz#56610bf3e4250df57744d61fbd95422e07dfb840"
+  integrity sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==
+  dependencies:
+    dompurify "*"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
@@ -1823,6 +1830,11 @@
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -3552,6 +3564,13 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+dompurify@*, dompurify@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
+  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- implement ClipboardUtils to sanitize HTML, upload pasted images, and support plain-text paste shortcut
- cover sanitization logic with tests

## Testing
- `npx -y yarn@1 lint`
- `npx -y yarn@1 test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5be3e0832887f98782d58578ca