### PR TITLE
feat: add client/server time skew handling

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,21 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import crypto from 'crypto';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.get('/api/time', (req, resp) => {
+      const serverTime = Date.now();
+      const clientTime = Number(req.headers['x-client-time']);
+      const skew = Number.isFinite(clientTime) ? serverTime - clientTime : 0;
+      const maxSkew = 5 * 60 * 1000; // 5 minutes
+      const signature = crypto
+        .createHmac('sha256', process.env.TIME_SECRET || 'gportfolio')
+        .update(serverTime.toString())
+        .digest('hex');
+      resp.json({ serverTime, skew, maxSkew, signature });
+    });
   }
 }

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,4 +1,7 @@
+import TimeSync from '../../../utils/TimeSync';
+
 (() => {
+  TimeSync.sync().then(() => TimeSync.warnIfSkewed());
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');

--- a/src/utils/TimeSync.ts
+++ b/src/utils/TimeSync.ts
@@ -1,0 +1,60 @@
+export default class TimeSync {
+  static skew = 0;
+
+  static maxSkew = 5 * 60 * 1000;
+
+  static warningId = 'time-skew-warning';
+
+  static async sync(): Promise<void> {
+    try {
+      const res = await fetch('/api/time', {
+        headers: {
+          'x-client-time': Date.now().toString(),
+        },
+      });
+      const data = await res.json();
+      if (typeof data.skew === 'number') {
+        TimeSync.skew = data.skew;
+      }
+      if (typeof data.maxSkew === 'number') {
+        TimeSync.maxSkew = data.maxSkew;
+      }
+    } catch (e) {
+      // ignore errors
+    }
+  }
+
+  static now(): number {
+    return Date.now() + TimeSync.skew;
+  }
+
+  static msUntil(timestamp: number): number {
+    return timestamp - TimeSync.now();
+  }
+
+  static isExpired(timestamp: number): boolean {
+    return TimeSync.now() >= timestamp;
+  }
+
+  static warnIfSkewed(): void {
+    if (Math.abs(TimeSync.skew) > TimeSync.maxSkew) {
+      if (!document.getElementById(TimeSync.warningId)) {
+        const el = document.createElement('div');
+        el.id = TimeSync.warningId;
+        el.textContent =
+          'Your device time differs from the server. Some features may not work correctly.';
+        el.style.position = 'fixed';
+        el.style.top = '0';
+        el.style.left = '0';
+        el.style.right = '0';
+        el.style.background = '#ffdd57';
+        el.style.color = '#000';
+        el.style.padding = '10px';
+        el.style.textAlign = 'center';
+        el.style.zIndex = '9999';
+        document.body.appendChild(el);
+      }
+    }
+  }
+}
+

--- a/src/utils/TimeUtils.ts
+++ b/src/utils/TimeUtils.ts
@@ -1,0 +1,10 @@
+import TimeSync from './TimeSync';
+
+export function getCountdownRemaining(target: number): number {
+  return Math.max(0, TimeSync.msUntil(target));
+}
+
+export function isTokenExpired(expiry: number): boolean {
+  return TimeSync.isExpired(expiry);
+}
+

--- a/tests/utils/TimeSync.test.ts
+++ b/tests/utils/TimeSync.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import TimeSync from '../../src/utils/TimeSync';
+import { getCountdownRemaining, isTokenExpired } from '../../src/utils/TimeUtils';
+
+describe('TimeSync utilities', () => {
+  beforeEach(() => {
+    TimeSync.skew = 0;
+    TimeSync.maxSkew = 5 * 60 * 1000;
+    document.body.innerHTML = '';
+  });
+
+  it('adjusts now using skew', () => {
+    TimeSync.skew = 2000;
+    const diff = TimeSync.now() - Date.now();
+    expect(diff).toBeGreaterThanOrEqual(2000);
+  });
+
+  it('calculates token expiry with skew', () => {
+    TimeSync.skew = 10000;
+    const expiry = Date.now() + 5000;
+    expect(isTokenExpired(expiry)).toBe(true);
+  });
+
+  it('calculates countdowns with skew', () => {
+    TimeSync.skew = -5000;
+    const target = Date.now() + 10000;
+    const remaining = getCountdownRemaining(target);
+    expect(remaining).toBeGreaterThan(10000);
+  });
+
+  it('shows warning when skew exceeds safe window', () => {
+    TimeSync.maxSkew = 1000;
+    TimeSync.skew = 5000;
+    TimeSync.warnIfSkewed();
+    expect(document.getElementById('time-skew-warning')).not.toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose `/api/time` endpoint returning signed server time and skew hint
- adjust client countdowns and token expiry calculations with synchronized time
- warn when clock skew exceeds safe window and cover with tests

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5e6da08328a1fe1017f04f8a5b