### PR TITLE
feat: add role-based onboarding checklist

### DIFF
--- a/src/modules/checklist/Checklist.ts
+++ b/src/modules/checklist/Checklist.ts
@@ -1,0 +1,115 @@
+export interface ChecklistTask {
+  id: string;
+  title: string;
+  page: string;
+  /** CSS selector of target control */
+  selector: string;
+}
+
+/**
+ * Simple onboarding checklist that persists progress in Storage.
+ * Tasks can be tied to a user role and linked to pages.
+ */
+export default class Checklist {
+  private readonly tasks: ChecklistTask[];
+
+  private readonly role: string;
+
+  private readonly storage: Storage;
+
+  private readonly baseKey: string;
+
+  constructor(role: string, tasks: ChecklistTask[], storage: Storage = window.localStorage) {
+    this.role = role;
+    this.tasks = tasks;
+    this.storage = storage;
+    this.baseKey = `checklist-${this.role}`;
+  }
+
+  private readProgress(): Set<string> {
+    const raw = this.storage.getItem(this.baseKey);
+    if (!raw) return new Set();
+    try {
+      const parsed: string[] = JSON.parse(raw);
+      return new Set(parsed);
+    } catch (e) {
+      return new Set();
+    }
+  }
+
+  private writeProgress(progress: Set<string>): void {
+    this.storage.setItem(this.baseKey, JSON.stringify(Array.from(progress)));
+  }
+
+  isTaskComplete(id: string): boolean {
+    return this.readProgress().has(id);
+  }
+
+  markTaskComplete(id: string): void {
+    const progress = this.readProgress();
+    progress.add(id);
+    this.writeProgress(progress);
+
+    if (this.allTasksCompleted()) {
+      this.storage.setItem(`${this.baseKey}-hidden`, 'true');
+      this.celebrate();
+    }
+  }
+
+  getPendingTasks(): ChecklistTask[] {
+    const progress = this.readProgress();
+    return this.tasks.filter((t) => !progress.has(t.id));
+  }
+
+  allTasksCompleted(): boolean {
+    return this.getPendingTasks().length === 0;
+  }
+
+  /** Returns whether checklist should be shown to the user */
+  shouldDisplay(): boolean {
+    return !this.storage.getItem(`${this.baseKey}-hidden`);
+  }
+
+  /** Highlights the target control for a task */
+  highlight(taskId: string): void {
+    const task = this.tasks.find((t) => t.id === taskId);
+    if (!task) return;
+    const el = document.querySelector(task.selector) as HTMLElement | null;
+    if (!el) return;
+    el.classList.add('checklist-highlight');
+    el.style.outline = '2px solid #ff9800';
+  }
+
+  /** Displays a dismissible celebration banner */
+  celebrate(): void {
+    const existing = document.getElementById('checklist-celebration');
+    if (existing) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.id = 'checklist-celebration';
+    wrapper.style.position = 'fixed';
+    wrapper.style.bottom = '1rem';
+    wrapper.style.right = '1rem';
+    wrapper.style.background = '#4caf50';
+    wrapper.style.color = '#fff';
+    wrapper.style.padding = '1rem';
+    wrapper.style.borderRadius = '4px';
+    wrapper.style.boxShadow = '0 2px 6px rgba(0,0,0,0.3)';
+
+    const msg = document.createElement('span');
+    msg.textContent = 'All tasks complete!';
+    wrapper.appendChild(msg);
+
+    const btn = document.createElement('button');
+    btn.textContent = '×';
+    btn.style.marginLeft = '0.5rem';
+    btn.style.background = 'transparent';
+    btn.style.border = 'none';
+    btn.style.color = '#fff';
+    btn.style.cursor = 'pointer';
+    btn.addEventListener('click', () => wrapper.remove());
+    wrapper.appendChild(btn);
+
+    document.body.appendChild(wrapper);
+  }
+}

--- a/src/modules/checklist/index.ts
+++ b/src/modules/checklist/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Checklist';
+export * from './Checklist';

--- a/tests/modules/Checklist.test.ts
+++ b/tests/modules/Checklist.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+import Checklist, { ChecklistTask } from '../../src/modules/checklist';
+
+class MemoryStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  get length(): number { return Object.keys(this.store).length; }
+  clear(): void { this.store = {}; }
+  getItem(key: string): string | null { return this.store[key] ?? null; }
+  key(index: number): string | null { return Object.keys(this.store)[index] ?? null; }
+  removeItem(key: string): void { delete this.store[key]; }
+  setItem(key: string, value: string): void { this.store[key] = value; }
+}
+
+const tasks: ChecklistTask[] = [
+  { id: 't1', title: 'Configure profile', page: '/config', selector: '#config' },
+  { id: 't2', title: 'Update bio', page: '/bio', selector: '#bio' },
+];
+
+describe('Checklist module', () => {
+  it('persists progress per role', () => {
+    const storage = new MemoryStorage();
+    let list = new Checklist('admin', tasks, storage);
+
+    expect(list.shouldDisplay()).toBe(true);
+    expect(list.getPendingTasks()).toHaveLength(2);
+
+    list.markTaskComplete('t1');
+    expect(list.isTaskComplete('t1')).toBe(true);
+
+    list = new Checklist('admin', tasks, storage);
+    expect(list.getPendingTasks()).toHaveLength(1);
+  });
+
+  it('hides after all tasks complete and celebration is dismissible', () => {
+    const storage = new MemoryStorage();
+    const list = new Checklist('user', tasks, storage);
+    document.body.innerHTML = '<div id="config"></div><div id="bio"></div>';
+
+    list.markTaskComplete('t1');
+    list.markTaskComplete('t2');
+
+    expect(list.shouldDisplay()).toBe(false);
+    const banner = document.getElementById('checklist-celebration');
+    expect(banner).not.toBeNull();
+    banner?.querySelector('button')?.dispatchEvent(new Event('click'));
+    expect(document.getElementById('checklist-celebration')).toBeNull();
+  });
+
+  it('highlights target control for a task', () => {
+    const storage = new MemoryStorage();
+    const list = new Checklist('user', tasks, storage);
+    document.body.innerHTML = '<div id="config"></div><div id="bio"></div>';
+    list.highlight('t1');
+    const el = document.getElementById('config');
+    expect(el?.classList.contains('checklist-highlight')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable checklist module with role-based progress persistence
- link tasks to pages and highlight elements with celebratory completion banner
- test checklist progress, celebration dismissal, and highlighting

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd5d4a64832886129b781378e9dc