### PR TITLE
Add undoable delete with confirmation

### DIFF
--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -85,5 +85,14 @@
         </div>
     </div>
 </section>
+<section>
+    <div class="section--name">
+        Danger Zone
+    </div>
+    <div class="section--items">
+        <button id="delete-account">Delete Account</button>
+        <div id="delete-status"></div>
+    </div>
+</section>
 </body>
 </html>

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,49 @@
+import DeleteManager from '../../utils/DeleteManager';
+
 (() => {
-  console.log('dev');
+  const button = document.getElementById('delete-account');
+  const status = document.getElementById('delete-status');
+
+  if (!button || !status) {
+    return;
+  }
+
+  button.addEventListener('click', () => {
+    // eslint-disable-next-line no-alert
+    const confirmed = window.confirm('This will permanently remove your data. You have 5 seconds to undo. Continue?');
+    if (!confirmed) {
+      return;
+    }
+
+    status.textContent = 'Pending delete...';
+
+    const progress = document.createElement('progress');
+    progress.max = 5;
+    progress.value = 0;
+    status.appendChild(progress);
+
+    const undoBtn = document.createElement('button');
+    undoBtn.textContent = 'Undo';
+    status.appendChild(undoBtn);
+
+    const op = DeleteManager.schedule(() => {
+      status.textContent = 'Deletion complete';
+    }, {
+      delayMs: 5000,
+      intervalMs: 1000,
+      onTick: (msLeft) => {
+        progress.value = (5 - msLeft / 1000);
+      },
+    });
+
+    undoBtn.addEventListener('click', () => {
+      op.undo();
+      status.textContent = 'Deletion cancelled';
+    });
+
+    op.promise.then(() => {
+      progress.remove();
+      undoBtn.remove();
+    });
+  });
 })();

--- a/src/utils/DeleteManager.ts
+++ b/src/utils/DeleteManager.ts
@@ -1,0 +1,72 @@
+import {
+  setTimeout as setTimeoutSafe,
+  clearTimeout as clearTimeoutSafe,
+  setInterval as setIntervalSafe,
+  clearInterval as clearIntervalSafe,
+} from 'timers';
+
+export interface DeleteOperation {
+  undo: () => void;
+  promise: Promise<void>;
+}
+
+export interface DeleteOptions {
+  delayMs?: number;
+  intervalMs?: number;
+  onTick?: (msLeft: number) => void;
+}
+
+export default class DeleteManager {
+  static schedule(
+    action: () => void | Promise<void>,
+    options: DeleteOptions = {},
+  ): DeleteOperation {
+    const { delayMs = 5000, intervalMs = 1000, onTick } = options;
+
+    let undone = false;
+    let timeout: NodeJS.Timeout;
+    let interval: NodeJS.Timeout | undefined;
+
+    const promise = new Promise<void>((resolve, reject) => {
+      let msLeft = delayMs;
+      if (onTick) {
+        onTick(msLeft);
+        interval = setIntervalSafe(() => {
+          msLeft -= intervalMs;
+          if (msLeft > 0) {
+            onTick(msLeft);
+          } else {
+            onTick(0);
+            clearIntervalSafe(interval as NodeJS.Timeout);
+          }
+        }, intervalMs);
+      }
+
+      timeout = setTimeoutSafe(() => {
+        if (interval) {
+          clearIntervalSafe(interval);
+        }
+        if (undone) {
+          resolve();
+          return;
+        }
+        Promise.resolve(action())
+          .then(resolve)
+          .catch(reject);
+      }, delayMs);
+    });
+
+    return {
+      undo: () => {
+        if (!undone) {
+          undone = true;
+          clearTimeoutSafe(timeout);
+          if (interval) {
+            clearIntervalSafe(interval);
+          }
+        }
+      },
+      promise,
+    };
+  }
+}

--- a/tests/utils/DeleteManager.test.ts
+++ b/tests/utils/DeleteManager.test.ts
@@ -1,0 +1,21 @@
+import DeleteManager from '../../src/utils/DeleteManager';
+
+jest.useFakeTimers();
+
+describe('DeleteManager', () => {
+  it('executes delete after delay', async () => {
+    const fn = jest.fn();
+    const op = DeleteManager.schedule(fn, { delayMs: 1000 });
+    jest.advanceTimersByTime(1000);
+    await op.promise;
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('can undo before delay', () => {
+    const fn = jest.fn();
+    const op = DeleteManager.schedule(fn, { delayMs: 1000 });
+    op.undo();
+    jest.advanceTimersByTime(1000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add DeleteManager utility to delay server deletes with undo window
- show confirmation dialog and progress UI for pending deletions
- test DeleteManager scheduling and undo behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd5fb05883288330a2aacc72cddf