### PR TITLE
Add payment test utilities

### DIFF
--- a/src/utils/PaymentTestUtils.ts
+++ b/src/utils/PaymentTestUtils.ts
@@ -1,0 +1,48 @@
+export interface FakeReceipt {
+  id: string;
+  amount: number;
+  currency: string;
+  description: string;
+  test: true;
+}
+
+export default class PaymentTestUtils {
+  static isTestKey(key: string): boolean {
+    return /^((sk|pk)_test_)/.test(key);
+  }
+
+  static assertTestKey(key: string): void {
+    if (!PaymentTestUtils.isTestKey(key)) {
+      throw new Error('Test key required. Live keys are not allowed in test mode.');
+    }
+  }
+
+  static testModeBanner(): string {
+    return 'TEST MODE — using test keys; operations are non-billable';
+  }
+
+  static generateFakeReceipt(amount: number, currency = 'usd', description = 'Test charge'): FakeReceipt {
+    const id = `rcpt_${Math.random().toString(36).substring(2, 10)}`;
+    return {
+      id,
+      amount,
+      currency,
+      description,
+      test: true,
+    };
+  }
+
+  static guardProduction(key: string, env: string): void {
+    if (env === 'production' && PaymentTestUtils.isTestKey(key)) {
+      throw new Error('Test keys must not be used in production.');
+    }
+  }
+
+  static demoCharge(amount: number): { success: boolean; billed: boolean; amount: number } {
+    return {
+      success: true,
+      billed: false,
+      amount,
+    };
+  }
+}

--- a/tests/utils/PaymentTestUtils.test.ts
+++ b/tests/utils/PaymentTestUtils.test.ts
@@ -1,0 +1,40 @@
+import PaymentTestUtils, { FakeReceipt } from '../../src/utils/PaymentTestUtils';
+
+describe('PaymentTestUtils', () => {
+  describe('isTestKey', () => {
+    it('detects test key', () => {
+      expect(PaymentTestUtils.isTestKey('sk_test_123')).toBe(true);
+      expect(PaymentTestUtils.isTestKey('pk_test_456')).toBe(true);
+      expect(PaymentTestUtils.isTestKey('sk_live_123')).toBe(false);
+    });
+  });
+
+  describe('assertTestKey', () => {
+    it('throws on live key', () => {
+      expect(() => PaymentTestUtils.assertTestKey('sk_live_123')).toThrow();
+    });
+  });
+
+  describe('generateFakeReceipt', () => {
+    it('creates non-billable receipt', () => {
+      const receipt: FakeReceipt = PaymentTestUtils.generateFakeReceipt(100, 'usd', 'Test');
+      expect(receipt.test).toBe(true);
+      expect(receipt.amount).toBe(100);
+      expect(receipt.currency).toBe('usd');
+    });
+  });
+
+  describe('guardProduction', () => {
+    it('blocks test key in production', () => {
+      expect(() => PaymentTestUtils.guardProduction('sk_test_123', 'production')).toThrow();
+    });
+  });
+
+  describe('demoCharge', () => {
+    it('simulates charge without billing', () => {
+      const result = PaymentTestUtils.demoCharge(250);
+      expect(result.billed).toBe(false);
+      expect(result.amount).toBe(250);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add payment test utility helpers for test-mode banner, fake receipts, and production guardrails
- add unit tests for payment test utilities

## Testing
- `yarn test tests/utils/PaymentTestUtils.test.ts`
- `yarn lint src/utils/PaymentTestUtils.ts tests/utils/PaymentTestUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd6290788328a9277c112649a46f