### PR TITLE
Add sandboxed iframe utility for untrusted content

### DIFF
--- a/src/utils/SandboxedIframe.ts
+++ b/src/utils/SandboxedIframe.ts
@@ -1,0 +1,89 @@
+export interface SandboxedIframeOptions {
+  /** URL of the third-party content */
+  src: string;
+  /** Origin allowed to communicate through the bridge */
+  allowedOrigin: string;
+  /** Capabilities allowed through the message bridge */
+  allowedCapabilities?: string[];
+  /** Callback when a warning should be displayed */
+  onWarning?: (message: string) => void;
+}
+
+export interface SandboxedIframeHandle {
+  iframe: HTMLIFrameElement;
+  /** send a message to the iframe */
+  postMessage: (data: any) => void;
+  /** destroy iframe and remove listeners */
+  destroy: () => void;
+}
+
+/**
+ * Create a sandboxed iframe for untrusted third‑party content.
+ * The iframe is isolated with strict permissions and communicates
+ * with the host page via a narrow, origin‑checked message bridge.
+ */
+export default function createSandboxedIframe(
+  container: HTMLElement,
+  options: SandboxedIframeOptions,
+): SandboxedIframeHandle {
+  const {
+    src,
+    allowedOrigin,
+    allowedCapabilities = [],
+    onWarning,
+  } = options;
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('sandbox', 'allow-scripts');
+  iframe.src = src;
+  iframe.style.border = '0';
+  container.appendChild(iframe);
+
+  const showWarning = (message: string): void => {
+    if (onWarning) {
+      onWarning(message);
+    }
+    const warning = document.createElement('div');
+    warning.className = 'iframe-warning';
+    warning.textContent = message;
+    warning.style.position = 'absolute';
+    warning.style.top = '0';
+    warning.style.left = '0';
+    warning.style.right = '0';
+    warning.style.background = 'rgba(255,0,0,0.8)';
+    warning.style.color = '#fff';
+    warning.style.padding = '4px';
+    container.appendChild(warning);
+  };
+
+  const handleMessage = (event: MessageEvent): void => {
+    if (event.source !== iframe.contentWindow) return;
+    if (event.origin !== allowedOrigin) return;
+    const { type, capability } = event.data || {};
+    if (type === 'request') {
+      if (!allowedCapabilities.includes(capability)) {
+        showWarning(`Capability "${capability}" blocked`);
+        if (typeof (event.source as Window | null)?.postMessage === 'function') {
+          (event.source as Window).postMessage({ type: 'blocked', capability }, event.origin);
+        }
+        return;
+      }
+      if (typeof (event.source as Window | null)?.postMessage === 'function') {
+        (event.source as Window).postMessage({ type: 'ack', capability }, event.origin);
+      }
+    }
+  };
+
+  window.addEventListener('message', handleMessage);
+
+  return {
+    iframe,
+    postMessage: (data: any) => {
+      iframe.contentWindow?.postMessage(data, allowedOrigin);
+    },
+    destroy: () => {
+      window.removeEventListener('message', handleMessage);
+      iframe.remove();
+    },
+  };
+}

--- a/tests/utils/SandboxedIframe.test.ts
+++ b/tests/utils/SandboxedIframe.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import createSandboxedIframe from '../../src/utils/SandboxedIframe';
+
+describe('createSandboxedIframe', () => {
+  it('creates iframe with sandbox attribute', () => {
+    const container = document.createElement('div');
+    const handle = createSandboxedIframe(container, {
+      src: 'https://example.com',
+      allowedOrigin: 'https://example.com',
+    });
+    expect(handle.iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    handle.destroy();
+  });
+
+  it('blocks disallowed capability and shows warning', () => {
+    const container = document.createElement('div');
+    const warn = jest.fn();
+    const handle = createSandboxedIframe(container, {
+      src: 'https://example.com',
+      allowedOrigin: 'https://example.com',
+      allowedCapabilities: ['ping'],
+      onWarning: warn,
+    });
+
+    const event = new MessageEvent('message', {
+      origin: 'https://example.com',
+      source: handle.iframe.contentWindow,
+      data: { type: 'request', capability: 'blocked' },
+    });
+    window.dispatchEvent(event);
+
+    expect(container.querySelector('.iframe-warning')).not.toBeNull();
+    expect(warn).toHaveBeenCalled();
+    handle.destroy();
+  });
+
+  it('ignores messages from other origins', () => {
+    const container = document.createElement('div');
+    const warn = jest.fn();
+    const handle = createSandboxedIframe(container, {
+      src: 'https://example.com',
+      allowedOrigin: 'https://example.com',
+      onWarning: warn,
+    });
+
+    const event = new MessageEvent('message', {
+      origin: 'https://evil.com',
+      source: handle.iframe.contentWindow,
+      data: { type: 'request', capability: 'blocked' },
+    });
+    window.dispatchEvent(event);
+
+    expect(container.querySelector('.iframe-warning')).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    handle.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add `createSandboxedIframe` helper to isolate third-party pages with a sandboxed `<iframe>`
- implement message bridge with origin checks and capability gating
- overlay visual warning when a requested capability is blocked
- add unit tests for allowed origins and blocked capabilities

## Testing
- `npx eslint --ext .ts .`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd6146d8832893c369673d81e0d6