### PR TITLE
feat: add request queuing and streaming parser

### DIFF
--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,3 +1,5 @@
+import './network';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {

--- a/src/templates/_common/scripts/network.ts
+++ b/src/templates/_common/scripts/network.ts
@@ -1,0 +1,11 @@
+import RequestQueue from '../../../utils/RequestQueue';
+import RequestQueueIndicator from '../../../utils/RequestQueueIndicator';
+
+const queue = new RequestQueue();
+
+window.addEventListener('load', () => {
+  RequestQueueIndicator.attach(queue);
+});
+
+// expose for other modules
+(window as any).requestQueue = queue;

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -1,0 +1,104 @@
+export interface QueueState {
+  endpoint: string;
+  queued: number;
+  running: number;
+  concurrency: number;
+}
+
+type Task<T> = () => Promise<T>;
+
+type Listener = (state: QueueState) => void;
+
+interface Queue {
+  concurrency: number;
+  running: number;
+  tasks: Task<any>[];
+}
+
+export default class RequestQueue {
+  private queues: Map<string, Queue> = new Map();
+
+  private listeners: Listener[] = [];
+
+  private defaultConcurrency: number;
+
+  constructor(defaultConcurrency = 4) {
+    this.defaultConcurrency = defaultConcurrency;
+  }
+
+  public setConcurrency(endpoint: string, limit: number): void {
+    const queue = this.getQueue(endpoint);
+    queue.concurrency = limit;
+    this.emit(endpoint);
+  }
+
+  public enqueue<T>(endpoint: string, task: Task<T>): Promise<T> {
+    const queue = this.getQueue(endpoint);
+    return new Promise<T>((resolve, reject) => {
+      queue.tasks.push(() => task().then(resolve, reject));
+      this.emit(endpoint);
+      this.next(endpoint);
+    });
+  }
+
+  public onChange(listener: Listener): void {
+    this.listeners.push(listener);
+  }
+
+  public getTotalQueued(): number {
+    let total = 0;
+    this.queues.forEach((q) => { total += q.tasks.length; });
+    return total;
+  }
+
+  public hasPaused(): boolean {
+    let paused = false;
+    this.queues.forEach((q) => {
+      if (q.tasks.length > 0 && q.running >= q.concurrency) {
+        paused = true;
+      }
+    });
+    return paused;
+  }
+
+  private next(endpoint: string): void {
+    const queue = this.getQueue(endpoint);
+    if (queue.running >= queue.concurrency) {
+      return;
+    }
+    const task = queue.tasks.shift();
+    if (!task) {
+      this.emit(endpoint);
+      return;
+    }
+    queue.running += 1;
+    this.emit(endpoint);
+    task().finally(() => {
+      queue.running -= 1;
+      this.emit(endpoint);
+      this.next(endpoint);
+    });
+  }
+
+  private emit(endpoint: string): void {
+    const queue = this.getQueue(endpoint);
+    const state: QueueState = {
+      endpoint,
+      queued: queue.tasks.length,
+      running: queue.running,
+      concurrency: queue.concurrency,
+    };
+    this.listeners.forEach((l) => l(state));
+  }
+
+  private getQueue(endpoint: string): Queue {
+    if (!this.queues.has(endpoint)) {
+      this.queues.set(endpoint, {
+        concurrency: this.defaultConcurrency,
+        running: 0,
+        tasks: [],
+      });
+    }
+    return this.queues.get(endpoint)!;
+  }
+}

--- a/src/utils/RequestQueueIndicator.ts
+++ b/src/utils/RequestQueueIndicator.ts
@@ -1,0 +1,31 @@
+import RequestQueue from './RequestQueue';
+
+export default class RequestQueueIndicator {
+  public static attach(queue: RequestQueue): void {
+    const indicator = document.createElement('div');
+    indicator.id = 'request-queue-indicator';
+    indicator.style.position = 'fixed';
+    indicator.style.bottom = '10px';
+    indicator.style.right = '10px';
+    indicator.style.padding = '4px 8px';
+    indicator.style.background = 'rgba(0,0,0,0.7)';
+    indicator.style.color = '#fff';
+    indicator.style.fontSize = '12px';
+    indicator.style.display = 'none';
+    document.body.appendChild(indicator);
+
+    const update = () => {
+      const queued = queue.getTotalQueued();
+      if (queued > 0) {
+        indicator.textContent = queue.hasPaused()
+          ? `Requests paused (${queued})`
+          : `Requests queued (${queued})`;
+        indicator.style.display = 'block';
+      } else {
+        indicator.style.display = 'none';
+      }
+    };
+
+    queue.onChange(() => update());
+  }
+}

--- a/src/utils/StreamingJsonParser.ts
+++ b/src/utils/StreamingJsonParser.ts
@@ -1,0 +1,51 @@
+export default class StreamingJsonParser {
+  public static async parse<T>(
+    stream: ReadableStream<Uint8Array>,
+    onValue: (value: T) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const abort = () => {
+      reader.cancel();
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        abort();
+        throw new Error('Aborted');
+      }
+      signal.addEventListener('abort', abort);
+    }
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let index;
+        while ((index = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, index).trim();
+          buffer = buffer.slice(index + 1);
+          if (line) {
+            onValue(JSON.parse(line));
+          }
+        }
+        if (signal?.aborted) {
+          abort();
+          throw new Error('Aborted');
+        }
+      }
+      const remaining = buffer.trim();
+      if (remaining) {
+        onValue(JSON.parse(remaining));
+      }
+    } finally {
+      if (signal) {
+        signal.removeEventListener('abort', abort);
+      }
+    }
+  }
+}

--- a/tests/utils/RequestQueue.test.ts
+++ b/tests/utils/RequestQueue.test.ts
@@ -1,0 +1,23 @@
+import RequestQueue from '../../src/utils/RequestQueue';
+
+describe('RequestQueue', () => {
+  it('limits concurrent requests per endpoint', async () => {
+    const queue = new RequestQueue();
+    queue.setConcurrency('test', 1);
+
+    const order: string[] = [];
+    let running = 0;
+
+    const makeTask = (id: number) => queue.enqueue('test', async () => {
+      order.push(`start${id}`);
+      running += 1;
+      expect(running).toBe(1);
+      await new Promise((r) => setTimeout(r, 5));
+      running -= 1;
+      order.push(`end${id}`);
+    });
+
+    await Promise.all([makeTask(1), makeTask(2), makeTask(3)]);
+    expect(order).toEqual(['start1', 'end1', 'start2', 'end2', 'start3', 'end3']);
+  });
+});

--- a/tests/utils/StreamingJsonParser.test.ts
+++ b/tests/utils/StreamingJsonParser.test.ts
@@ -1,0 +1,60 @@
+import StreamingJsonParser from '../../src/utils/StreamingJsonParser';
+
+class MockReadableStream {
+  private chunks: Uint8Array[];
+
+  private delay: number;
+
+  constructor(chunks: Uint8Array[], delay = 0) {
+    this.chunks = chunks;
+    this.delay = delay;
+  }
+
+  getReader() {
+    let index = 0;
+    const { chunks, delay } = this;
+    return {
+      read: () => new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+        if (index >= chunks.length) {
+          resolve({ value: undefined, done: true });
+          return;
+        }
+        const value = chunks[index++];
+        if (delay) {
+          setTimeout(() => resolve({ value, done: false }), delay);
+        } else {
+          resolve({ value, done: false });
+        }
+      }),
+      cancel: () => Promise.resolve(),
+    };
+  }
+}
+
+describe('StreamingJsonParser', () => {
+  it('parses ndjson stream', async () => {
+    const stream = new MockReadableStream([
+      new TextEncoder().encode('{"a":1}\n'),
+      new TextEncoder().encode('{"a":2}\n'),
+      new TextEncoder().encode('{"a":3}\n'),
+    ]) as unknown as ReadableStream<Uint8Array>;
+    const values: any[] = [];
+    await StreamingJsonParser.parse(stream, (v) => values.push(v));
+    expect(values).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  });
+
+  it('aborts parsing when signal triggers', async () => {
+    const controller = new AbortController();
+    const stream = new MockReadableStream([
+      new TextEncoder().encode('{"a":1}\n'),
+      new TextEncoder().encode('{"a":2}\n'),
+    ], 5) as unknown as ReadableStream<Uint8Array>;
+    const values: any[] = [];
+    const promise = StreamingJsonParser.parse(stream, (v) => {
+      values.push(v);
+      controller.abort();
+    }, controller.signal);
+    await expect(promise).rejects.toThrow('Aborted');
+    expect(values).toEqual([{ a: 1 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement generic RequestQueue with per-endpoint concurrency control
- add StreamingJsonParser with abort support for large responses
- expose queue with UI indicator for queued and paused requests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fd6582308328be7894ff05d7b938