### PR TITLE
Handle IME composition events in inputs

### DIFF
--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,7 @@
-(() => {
-  console.log('dev');
-})();
+import { bindCompositionInput } from '../../utils/CompositionInputHandler';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('input').forEach((el) => {
+    bindCompositionInput(el as HTMLInputElement, (value) => value);
+  });
+});

--- a/src/utils/CompositionInputHandler.ts
+++ b/src/utils/CompositionInputHandler.ts
@@ -1,0 +1,37 @@
+export type Validator = (value: string) => string;
+
+export function bindCompositionInput(
+  input: HTMLInputElement,
+  validator: Validator,
+): void {
+  let isComposing = false;
+
+  const runValidation = (): void => {
+    const { selectionStart, selectionEnd } = input;
+    const newValue = validator(input.value);
+    if (input.value !== newValue) {
+      input.value = newValue;
+      if (selectionStart !== null && selectionEnd !== null) {
+        input.setSelectionRange(selectionStart, selectionEnd);
+      }
+    }
+  };
+
+  input.addEventListener('compositionstart', () => {
+    isComposing = true;
+  });
+
+  input.addEventListener('compositionupdate', () => {
+    // ignore updates during composition
+  });
+
+  input.addEventListener('compositionend', () => {
+    isComposing = false;
+  });
+
+  input.addEventListener('input', () => {
+    if (!isComposing) {
+      runValidation();
+    }
+  });
+}

--- a/tests/utils/CompositionInputHandler.test.ts
+++ b/tests/utils/CompositionInputHandler.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { bindCompositionInput } from '../../src/utils/CompositionInputHandler';
+
+describe('bindCompositionInput', () => {
+  it('defers validation until compositionend', () => {
+    const input = document.createElement('input');
+    const validator = jest.fn((v: string) => v);
+    bindCompositionInput(input, validator);
+
+    input.value = '';
+    input.dispatchEvent(new CompositionEvent('compositionstart'));
+    input.value = 'あ';
+    input.dispatchEvent(new InputEvent('input'));
+    expect(validator).not.toHaveBeenCalled();
+
+    input.dispatchEvent(new CompositionEvent('compositionend'));
+    input.dispatchEvent(new InputEvent('input'));
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts IME characters without caret jumps', () => {
+    const input = document.createElement('input');
+    const validator = jest.fn((v: string) => v.replace(/\d/g, ''));
+    bindCompositionInput(input, validator);
+
+    input.value = '';
+    input.dispatchEvent(new CompositionEvent('compositionstart'));
+    input.value = 'あ';
+    input.setSelectionRange(1, 1);
+    input.dispatchEvent(new InputEvent('input'));
+
+    input.dispatchEvent(new CompositionEvent('compositionend'));
+    input.dispatchEvent(new InputEvent('input'));
+
+    expect(input.value).toBe('あ');
+    expect(input.selectionStart).toBe(1);
+    expect(input.selectionEnd).toBe(1);
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- respect `compositionstart`/`update`/`end` in input handler and delay validation until input after composition
- wire composition-aware handler to config page inputs
- add jsdom tests covering IME composition and caret preservation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fee7e7008328a2ba5861260c3b3f