### PR TITLE
Handle oversized text and improve copy UX

### DIFF
--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -55,35 +55,57 @@
 <!--        </div>-->
 <!--    </div>-->
 <!--</section>-->
-<section>
-    <div class="section--name">
-        Global
-    </div>
-    <div class="section--items">
-        <div class="block">
+  <section>
+      <div class="section--name">
+          Global
+      </div>
+      <div class="section--items">
+          <div class="block">
             <div class="block--label">
                 Template
             </div>
-            <div class="block--input">
-                <input/>
-            </div>
-            <div class="block--description">
-                Select an existing template
-            </div>
-        </div>
-        <div class="block">
+              <div class="block--input">
+                  <input/>
+              </div>
+              <div class="block--description">
+                  Select an existing template
+              </div>
+          </div>
+          <div class="block">
             <div class="block--label">
                 Base
             </div>
-            <div class="block--input">
-                <input/>
-            </div>
-            <div class="block--description">
-                If the repository is called: &lt;username&gt;.github.io. Then the value is empty
-                If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;
-            </div>
-        </div>
-    </div>
-</section>
+              <div class="block--input">
+                  <input/>
+              </div>
+              <div class="block--description">
+                  If the repository is called: &lt;username&gt;.github.io. Then the value is empty
+                  If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;
+              </div>
+          </div>
+          <div class="block">
+              <div class="block--label">
+                  Description
+              </div>
+              <div class="block--input">
+                  <textarea data-autosize></textarea>
+              </div>
+              <div class="block--description">
+                  Provide a description for your portfolio.
+              </div>
+          </div>
+          <div class="block">
+              <div class="block--label">
+                  Portfolio ID
+              </div>
+              <div class="block--input">
+                  <span data-copy-id class="long-id">1234567890abcdefghijklmnopqrstuvwxyz</span>
+              </div>
+              <div class="block--description">
+                  Long identifier with copy support.
+              </div>
+          </div>
+      </div>
+  </section>
 </body>
 </html>

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,15 @@
+import TextareaUtils from '../../utils/TextareaUtils';
+import CopyUtils from '../../utils/CopyUtils';
+import StringUtils from '../../utils/StringUtils';
+
 (() => {
-  console.log('dev');
+  window.addEventListener('DOMContentLoaded', () => {
+    TextareaUtils.autoSizeAll();
+    CopyUtils.attachCopyButtons();
+    const ids = document.querySelectorAll<HTMLElement>('[data-copy-id]');
+    ids.forEach((el) => {
+      // eslint-disable-next-line no-param-reassign
+      el.textContent = StringUtils.softHyphenate(el.textContent || '');
+    });
+  });
 })();

--- a/src/pages/config/styles/global.scss
+++ b/src/pages/config/styles/global.scss
@@ -13,18 +13,40 @@ html {
   background-color: var(--primary);
 }
 
-body {
-  font-family: JetBrainsMono, monospace;
-  font-size: 13px;
-  line-height: 1.2;
-  color: #fff;
-}
+  body {
+    font-family: JetBrainsMono, monospace;
+    font-size: 13px;
+    line-height: 1.2;
+    color: #fff;
+  }
 
-input {
-  border: 0;
-  outline: 0;
-  padding: 7px 10px;
-  background-color: #393e46;
-  border-radius: 5px;
-  color: #fff;
-}
+  input {
+    border: 0;
+    outline: 0;
+    padding: 7px 10px;
+    background-color: #393e46;
+    border-radius: 5px;
+    color: #fff;
+  }
+
+  textarea {
+    border: 0;
+    outline: 0;
+    padding: 7px 10px;
+    background-color: #393e46;
+    border-radius: 5px;
+    color: #fff;
+    width: 100%;
+    resize: none;
+    overflow: hidden;
+  }
+
+  .long-id {
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
+
+  .copy-btn {
+    margin-left: 5px;
+    cursor: pointer;
+  }

--- a/src/utils/CopyUtils.ts
+++ b/src/utils/CopyUtils.ts
@@ -1,0 +1,17 @@
+export default class CopyUtils {
+  static attachCopyButtons(selector = '[data-copy-id]'): void {
+    const elements = Array.from(document.querySelectorAll<HTMLElement>(selector));
+    elements.forEach((el) => {
+      const button = document.createElement('button');
+      button.textContent = 'Copy';
+      button.className = 'copy-btn';
+      button.addEventListener('click', () => {
+        const text = el.textContent || '';
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text);
+        }
+      });
+      el.insertAdjacentElement('afterend', button);
+    });
+  }
+}

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -10,4 +10,9 @@ export default class StringUtils {
       ? str.substring(0, str.length - 1)
       : str;
   }
+
+  static softHyphenate(str: string, size = 10): string {
+    const reg = new RegExp(`(\\S{${size}})(?=\\S)`, 'g');
+    return str.replace(reg, '$1\u00AD');
+  }
 }

--- a/src/utils/TextareaUtils.ts
+++ b/src/utils/TextareaUtils.ts
@@ -1,0 +1,18 @@
+export default class TextareaUtils {
+  static autoSize(textarea: HTMLTextAreaElement, maxHeight = 300): void {
+    const el = textarea;
+    const resize = () => {
+      el.style.height = 'auto';
+      const newHeight = Math.min(el.scrollHeight, maxHeight);
+      el.style.height = `${newHeight}px`;
+      el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    };
+    el.addEventListener('input', resize);
+    resize();
+  }
+
+  static autoSizeAll(selector = 'textarea[data-autosize]', maxHeight = 300): void {
+    const textareas = Array.from(document.querySelectorAll<HTMLTextAreaElement>(selector));
+    textareas.forEach((ta) => TextareaUtils.autoSize(ta, maxHeight));
+  }
+}

--- a/tests/pages/config/Layout.test.ts
+++ b/tests/pages/config/Layout.test.ts
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+import StringUtils from '../../../src/utils/StringUtils';
+
+describe('config page layout', () => {
+  test('soft hyphen prevents layout distortion', () => {
+    const span = document.createElement('span');
+    span.className = 'long-id';
+    span.textContent = '123456789012345678901234567890';
+    document.body.appendChild(span);
+    span.textContent = StringUtils.softHyphenate(span.textContent || '', 5);
+    expect(span.textContent).toContain('\u00AD');
+  });
+});

--- a/tests/utils/CopyUtils.test.ts
+++ b/tests/utils/CopyUtils.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import CopyUtils from '../../src/utils/CopyUtils';
+
+describe('CopyUtils', () => {
+  test('adds copy button and copies text', () => {
+    const span = document.createElement('span');
+    span.textContent = 'longid';
+    span.setAttribute('data-copy-id', '');
+    document.body.appendChild(span);
+
+    const writeText = jest.fn();
+    // @ts-ignore
+    navigator.clipboard = { writeText };
+
+    CopyUtils.attachCopyButtons();
+
+    const btn = document.querySelector('button.copy-btn') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(writeText).toHaveBeenCalledWith('longid');
+  });
+});

--- a/tests/utils/StringUtils.test.ts
+++ b/tests/utils/StringUtils.test.ts
@@ -20,4 +20,12 @@ describe('StringUtils', () => {
       expect(url).toBe('https://example.com');
     });
   });
+
+  describe('softHyphenate', () => {
+    it('inserts soft hyphens into long tokens', () => {
+      const input = 'abcdefghijK';
+      const result = StringUtils.softHyphenate(input, 5);
+      expect(result).toBe('abcde\u00ADfghij\u00ADK');
+    });
+  });
 });

--- a/tests/utils/TextareaUtils.test.ts
+++ b/tests/utils/TextareaUtils.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import TextareaUtils from '../../src/utils/TextareaUtils';
+
+describe('TextareaUtils', () => {
+  test('autoSize adjusts height under max', () => {
+    const ta = document.createElement('textarea');
+    Object.defineProperty(ta, 'scrollHeight', { get: () => 50 });
+    document.body.appendChild(ta);
+    TextareaUtils.autoSize(ta, 100);
+    expect(ta.style.height).toBe('50px');
+    expect(ta.style.overflowY).toBe('hidden');
+  });
+
+  test('autoSize limits height over max', () => {
+    const ta = document.createElement('textarea');
+    Object.defineProperty(ta, 'scrollHeight', { get: () => 500 });
+    document.body.appendChild(ta);
+    TextareaUtils.autoSize(ta, 100);
+    expect(ta.style.height).toBe('100px');
+    expect(ta.style.overflowY).toBe('auto');
+  });
+});


### PR DESCRIPTION
## Summary
- auto-resize textareas with a maximum height and scroll
- hyphenate long tokens and add copy buttons for IDs
- ensure layout handles long content through tests

## Testing
- `npm test -- --runInBand`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b3feeb44c4832899536652298b306e