### PR TITLE
Add multi-select interactions

### DIFF
--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -92,6 +92,7 @@ function generateRepositoriesHtml(repositories) {
         <div class="repositories">
           <%= generateRepositoriesHtml(canShowMoreRepositories ? repositories.slice(0, repositoriesMore) : repositories) %>
         </div>
+        <div class="batch-actions">Actions for selected items</div>
         <% if (canShowMoreRepositories) { %>
           <div class="text--center mt-50">
             <div id="github-more" class="btn-more">Show more</div>

--- a/src/templates/default/index.ts
+++ b/src/templates/default/index.ts
@@ -1,1 +1,2 @@
 import '../_common/scripts';
+import './scripts/repository-selection';

--- a/src/templates/default/scripts/repository-selection.ts
+++ b/src/templates/default/scripts/repository-selection.ts
@@ -1,0 +1,186 @@
+interface SelectionState {
+  lastIndex: number | null;
+  selected: Set<HTMLElement>;
+}
+
+const state: SelectionState = {
+  lastIndex: null,
+  selected: new Set(),
+};
+
+function updateBatchActions(): void {
+  const batch = document.querySelector('.batch-actions') as HTMLElement | null;
+  if (!batch) {
+    return;
+  }
+  batch.style.display = state.selected.size > 1 ? 'block' : 'none';
+}
+
+function selectItem(item: HTMLElement): void {
+  if (!state.selected.has(item)) {
+    item.classList.add('selected');
+    state.selected.add(item);
+  }
+}
+
+function deselectItem(item: HTMLElement): void {
+  if (state.selected.has(item)) {
+    item.classList.remove('selected');
+    state.selected.delete(item);
+  }
+}
+
+function clearSelection(): void {
+  state.selected.forEach((i) => i.classList.remove('selected'));
+  state.selected.clear();
+  state.lastIndex = null;
+  updateBatchActions();
+}
+
+function selectRange(items: HTMLElement[], start: number, end: number): void {
+  const [s, e] = start < end ? [start, end] : [end, start];
+  for (let i = s; i <= e; i += 1) {
+    selectItem(items[i]);
+  }
+}
+
+function handleClick(e: MouseEvent): void {
+  const container = e.currentTarget as HTMLElement;
+  const target = (e.target as HTMLElement).closest('.repository') as HTMLElement | null;
+  if (!target) {
+    return;
+  }
+  const items = Array.from(container.querySelectorAll('.repository')) as HTMLElement[];
+  const index = items.indexOf(target);
+  if (e.shiftKey && state.lastIndex !== null) {
+    selectRange(items, state.lastIndex, index);
+  } else if (state.selected.has(target)) {
+    deselectItem(target);
+    state.lastIndex = null;
+  } else {
+    selectItem(target);
+    state.lastIndex = index;
+  }
+  updateBatchActions();
+  if (!e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+  }
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+  const container = document.querySelector('.repositories');
+  if (!container) {
+    return;
+  }
+  const items = Array.from(container.querySelectorAll('.repository')) as HTMLElement[];
+  const active = document.activeElement as HTMLElement;
+  const index = items.indexOf(active);
+  if (e.key === 'a' && e.ctrlKey) {
+    items.forEach(selectItem);
+    updateBatchActions();
+    e.preventDefault();
+    return;
+  }
+  if (e.key === 'Escape') {
+    clearSelection();
+    e.preventDefault();
+    return;
+  }
+  if (index === -1) {
+    return;
+  }
+  let next = index;
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+    next = Math.min(items.length - 1, index + 1);
+  } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+    next = Math.max(0, index - 1);
+  }
+  if (next !== index) {
+    items[next].focus();
+    if (e.shiftKey && state.lastIndex !== null) {
+      clearSelection();
+      selectRange(items, state.lastIndex, next);
+    } else if (e.shiftKey) {
+      selectRange(items, index, next);
+      state.lastIndex = index;
+    } else {
+      state.lastIndex = next;
+    }
+    updateBatchActions();
+    e.preventDefault();
+  }
+}
+
+function initDrag(container: HTMLElement): void {
+  let startX = 0;
+  let startY = 0;
+  let box: HTMLDivElement | null = null;
+  function onMouseMove(ev: MouseEvent): void {
+    if (!box) {
+      return;
+    }
+    const x = Math.min(ev.pageX, startX);
+    const y = Math.min(ev.pageY, startY);
+    box.style.left = `${x}px`;
+    box.style.top = `${y}px`;
+    box.style.width = `${Math.abs(ev.pageX - startX)}px`;
+    box.style.height = `${Math.abs(ev.pageY - startY)}px`;
+  }
+  function onMouseUp(): void {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    if (!box) {
+      return;
+    }
+    const rect = box.getBoundingClientRect();
+    box.remove();
+    box = null;
+    const items = Array.from(container.querySelectorAll('.repository')) as HTMLElement[];
+    clearSelection();
+    items.forEach((item, i) => {
+      const r = item.getBoundingClientRect();
+      if (
+        r.left < rect.right
+        && r.right > rect.left
+        && r.top < rect.bottom
+        && r.bottom > rect.top
+      ) {
+        selectItem(item);
+        state.lastIndex = i;
+      }
+    });
+    updateBatchActions();
+  }
+  container.addEventListener('mousedown', (ev: MouseEvent) => {
+    if (ev.button !== 0) {
+      return;
+    }
+    if ((ev.target as HTMLElement).closest('.repository')) {
+      return;
+    }
+    startX = ev.pageX;
+    startY = ev.pageY;
+    box = document.createElement('div');
+    box.className = 'selection-box';
+    box.style.left = `${startX}px`;
+    box.style.top = `${startY}px`;
+    document.body.appendChild(box);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    ev.preventDefault();
+  });
+}
+
+export default function enableRepositorySelection(): void {
+  const container = document.querySelector('.repositories') as HTMLElement | null;
+  if (!container) {
+    return;
+  }
+  container.addEventListener('click', handleClick);
+  document.addEventListener('keydown', handleKeydown);
+  initDrag(container);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  enableRepositorySelection();
+});

--- a/src/templates/default/styles/repositories.scss
+++ b/src/templates/default/styles/repositories.scss
@@ -68,3 +68,19 @@
     }
   }
 }
+.repository.selected {
+  outline: 2px solid #474a73;
+}
+
+.selection-box {
+  position: absolute;
+  border: 1px dashed #474a73;
+  background: rgba(71, 74, 115, 0.1);
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.batch-actions {
+  display: none;
+  margin-top: 20px;
+}

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,0 +1,8 @@
+export default function selectRange<T>(items: T[], start: number, end: number): T[] {
+  const [s, e] = start < end ? [start, end] : [end, start];
+  const result: T[] = [];
+  for (let i = s; i <= e && i < items.length; i += 1) {
+    result.push(items[i]);
+  }
+  return result;
+}

--- a/tests/utils/Selection.test.ts
+++ b/tests/utils/Selection.test.ts
@@ -1,0 +1,13 @@
+import { performance } from 'perf_hooks';
+import selectRange from '../../src/utils/selection';
+
+describe('selection utils', () => {
+  it('selectRange handles large selections efficiently', () => {
+    const items = Array.from({ length: 10000 }, (_, i) => i);
+    const start = performance.now();
+    const result = selectRange(items, 100, 9900);
+    const duration = performance.now() - start;
+    expect(result.length).toBe(9801);
+    expect(duration).toBeLessThan(50);
+  });
+});


### PR DESCRIPTION
## Summary
- implement shift-click range selection and keyboard navigation
- add drag-selection rectangle and conditional batch actions display
- stress-test selection utils for performance

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b3feee03d08328ab6ef5686f49c6be