### PR TITLE
feat: add WebRTC DataChannel and file validation utilities

### DIFF
--- a/src/services/webrtc/DataChannel.ts
+++ b/src/services/webrtc/DataChannel.ts
@@ -1,0 +1,88 @@
+export interface DataChannelOptions {
+  /** Optional TURN server details */
+  turnServer?: RTCIceServer;
+}
+
+/**
+ * Utility to establish a WebRTC DataChannel connection using a simple join
+ * code workflow. The host creates an offer and shares the encoded join code
+ * with a peer. The peer accepts the offer, returning an answer code which the
+ * host applies to finalize the connection.
+ *
+ * TURN servers are disabled by default. Administrators may enable TURN at
+ * runtime using {@link enableTurn}.
+ */
+export default class DataChannel {
+  private pc: RTCPeerConnection;
+
+  private channel?: RTCDataChannel;
+
+  private turnEnabled = false;
+
+  private readonly options: DataChannelOptions;
+
+  constructor(options: DataChannelOptions = {}) {
+    this.options = options;
+    this.pc = this.createPeerConnection();
+  }
+
+  /** Toggle usage of the configured TURN server. */
+  public enableTurn(enable: boolean) {
+    this.turnEnabled = enable;
+    // Recreate connection so new ICE servers take effect
+    const label = this.channel?.label ?? 'data';
+    this.pc = this.createPeerConnection();
+    if (this.channel) {
+      this.channel = this.pc.createDataChannel(label);
+    }
+  }
+
+  private createPeerConnection() {
+    const iceServers: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+    if (this.turnEnabled && this.options.turnServer) {
+      iceServers.push(this.options.turnServer);
+    }
+    return new RTCPeerConnection({ iceServers });
+  }
+
+  /** Host side: create offer and return encoded join code. */
+  public async createJoinCode(label = 'data'): Promise<string> {
+    this.channel = this.pc.createDataChannel(label);
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
+    return this.encode(this.pc.localDescription as RTCSessionDescriptionInit);
+  }
+
+  /**
+   * Peer side: accept a join code (offer) and return answer code & DataChannel.
+   */
+  public acceptJoinCode(code: string): Promise<{ answer: string; channel: RTCDataChannel }> {
+    const offer = this.decode(code);
+    return new Promise((resolve, reject) => {
+      this.pc.ondatachannel = async (ev) => {
+        const answer = await this.pc.createAnswer();
+        await this.pc.setLocalDescription(answer);
+        resolve({
+          answer: this.encode(this.pc.localDescription as RTCSessionDescriptionInit),
+          channel: ev.channel,
+        });
+      };
+      this.pc.setRemoteDescription(offer).catch(reject);
+    });
+  }
+
+  /** Host side: finalize the connection using peer's answer code. */
+  public async completeJoin(answerCode: string): Promise<RTCDataChannel> {
+    const answer = this.decode(answerCode);
+    await this.pc.setRemoteDescription(answer);
+    return this.channel as RTCDataChannel;
+  }
+
+  private encode(desc: RTCSessionDescriptionInit): string {
+    return Buffer.from(JSON.stringify(desc)).toString('base64');
+  }
+
+  private decode(code: string): RTCSessionDescriptionInit {
+    return JSON.parse(Buffer.from(code, 'base64').toString());
+  }
+}

--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -1,0 +1,22 @@
+export default class FileUtils {
+  /**
+   * Validate file size & type then return SHA-256 hash.
+   * @throws Error when validation fails.
+   */
+  static async validateAndHash(
+    file: File,
+    allowedTypes: string[],
+    maxSize: number,
+  ): Promise<string> {
+    if (allowedTypes.length && !allowedTypes.includes(file.type)) {
+      throw new Error('Invalid file type');
+    }
+    if (file.size > maxSize) {
+      throw new Error('File too large');
+    }
+    const buffer = await file.arrayBuffer();
+    const digest = await crypto.subtle.digest('SHA-256', buffer);
+    const hashArray = Array.from(new Uint8Array(digest));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+}

--- a/tests/utils/FileUtils.test.ts
+++ b/tests/utils/FileUtils.test.ts
@@ -1,0 +1,24 @@
+import FileUtils from '../../src/utils/FileUtils';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { File } = require('buffer');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+global.crypto = require('crypto').webcrypto;
+
+describe('FileUtils', () => {
+  it('hashes valid file', async () => {
+    const file = new File([Buffer.from('hello')], 'hello.txt', { type: 'text/plain' });
+    const hash = await FileUtils.validateAndHash(file, ['text/plain'], 1024);
+    expect(hash).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+  });
+
+  it('rejects invalid type', async () => {
+    const file = new File([Buffer.from('hello')], 'hello.txt', { type: 'text/plain' });
+    await expect(FileUtils.validateAndHash(file, ['image/png'], 1024)).rejects.toThrow('Invalid file type');
+  });
+
+  it('rejects large file', async () => {
+    const file = new File([Buffer.alloc(2000)], 'big.txt', { type: 'text/plain' });
+    await expect(FileUtils.validateAndHash(file, ['text/plain'], 1024)).rejects.toThrow('File too large');
+  });
+});


### PR DESCRIPTION
## Summary
- add WebRTC DataChannel service using join-code workflow with optional TURN
- add client-side file validation and hashing utility
- test file validation edge cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3feef12a48328ba2cf2727de61607