### PR TITLE
feat: enable tenant theming

### DIFF
--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,4 +1,7 @@
+import { applyTenantConfig } from '../../../utils/tenant';
+
 (() => {
+  applyTenantConfig();
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');

--- a/src/templates/default/index.ejs
+++ b/src/templates/default/index.ejs
@@ -62,6 +62,7 @@ function generateRepositoriesHtml(repositories) {
   <div class="header__background background--image"></div>
   <div class="header__wrap">
     <div class="header__wrap__image avatar--image"></div>
+    <img id="logo" class="header__wrap__logo" alt="logo" />
     <h1 class="header__wrap__name"><%= `${config.data.first_name} ${config.data.last_name}` %></h1>
     <% if (config.data.position) { %>
       <span class="header__wrap__position"><%= config.data.position %></span>

--- a/src/utils/tenant.ts
+++ b/src/utils/tenant.ts
@@ -1,0 +1,102 @@
+type ThemeTokens = Record<string, string>;
+
+export interface TenantOgMeta {
+  title: string;
+  description: string;
+  image: string;
+}
+
+export interface TenantConfig {
+  tokens: ThemeTokens;
+  logo: string;
+  og: TenantOgMeta;
+}
+
+const DEFAULT_TENANT = 'default';
+
+const TENANTS: Record<string, TenantConfig> = {
+  'brand-a.example.com': {
+    tokens: {
+      'color-primary': '#0d6efd',
+      'color-secondary': '#6610f2',
+    },
+    logo: '/assets/brand-a-logo.png',
+    og: {
+      title: 'Brand A Portfolio',
+      description: 'Portfolio for Brand A',
+      image: '/assets/brand-a-og.png',
+    },
+  },
+  'brand-b.example.com': {
+    tokens: {
+      'color-primary': '#198754',
+      'color-secondary': '#20c997',
+    },
+    logo: '/assets/brand-b-logo.png',
+    og: {
+      title: 'Brand B Portfolio',
+      description: 'Portfolio for Brand B',
+      image: '/assets/brand-b-og.png',
+    },
+  },
+  [DEFAULT_TENANT]: {
+    tokens: {
+      'color-primary': '#000000',
+      'color-secondary': '#ffffff',
+    },
+    logo: '/assets/logo.png',
+    og: {
+      title: 'Portfolio',
+      description: 'Default portfolio',
+      image: '/assets/og.png',
+    },
+  },
+};
+
+export function getTenantConfig(hostname: string = window.location.hostname): TenantConfig {
+  return TENANTS[hostname] || TENANTS[DEFAULT_TENANT];
+}
+
+export function createTenantStorage(
+  hostname: string = window.location.hostname,
+  storage: Storage = window.localStorage,
+) {
+  return {
+    getItem: (key: string) => storage.getItem(`${hostname}:${key}`),
+    setItem: (key: string, value: string) => storage.setItem(`${hostname}:${key}`, value),
+    removeItem: (key: string) => storage.removeItem(`${hostname}:${key}`),
+  };
+}
+
+export function applyTenantConfig(doc: Document = document): TenantConfig {
+  const tenant = getTenantConfig();
+  Object.entries(tenant.tokens).forEach(([key, value]) => {
+    (doc as any).documentElement.style.setProperty(`--${key}`, value);
+  });
+  const logoEl = (doc.getElementById && doc.getElementById('logo')) as HTMLImageElement | null;
+  if (logoEl) {
+    logoEl.src = tenant.logo;
+  }
+
+  const ensureMeta = (property: string, content: string) => {
+    let el = doc.head.querySelector(`meta[property='${property}']`) as HTMLMetaElement | null;
+    if (!el && doc.createElement) {
+      el = doc.createElement('meta');
+      el.setAttribute('property', property);
+      doc.head.appendChild(el);
+    }
+    if (el) {
+      el.setAttribute('content', content);
+    }
+  };
+
+  ensureMeta('og:title', tenant.og.title);
+  ensureMeta('og:description', tenant.og.description);
+  ensureMeta('og:image', tenant.og.image);
+
+  if (typeof window !== 'undefined') {
+    (window as any).tenantStorage = createTenantStorage();
+  }
+
+  return tenant;
+}

--- a/tests/utils/tenant.test.ts
+++ b/tests/utils/tenant.test.ts
@@ -1,0 +1,28 @@
+import { getTenantConfig, createTenantStorage } from '../../src/utils/tenant';
+
+describe('tenant utilities', () => {
+  it('returns default tenant for unknown hostname', () => {
+    const cfg = getTenantConfig('unknown');
+    expect(cfg.logo).toBe('/assets/logo.png');
+  });
+
+  it('isolates storage by hostname', () => {
+    const backing: Record<string, string> = {};
+    const fakeStorage = {
+      getItem: (k: string) => backing[k] || null,
+      setItem: (k: string, v: string) => { backing[k] = v; },
+      removeItem: (k: string) => { delete backing[k]; },
+    } as Storage;
+
+    const a = createTenantStorage('a.com', fakeStorage);
+    const b = createTenantStorage('b.com', fakeStorage);
+
+    a.setItem('token', '1');
+    b.setItem('token', '2');
+
+    expect(backing['a.com:token']).toBe('1');
+    expect(backing['b.com:token']).toBe('2');
+    expect(a.getItem('token')).toBe('1');
+    expect(b.getItem('token')).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary
- load tenant theme, logo, and OG metadata based on hostname
- isolate storage per hostname and expose utility
- apply tenant config on startup and add logo placeholder

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fef05a0c8328b45df912bbd6e14e