### PR TITLE
Add event schema and emitter

### DIFF
--- a/src/modules/events/EventEmitter.ts
+++ b/src/modules/events/EventEmitter.ts
@@ -1,0 +1,45 @@
+import IEvent from './interfaces/IEvent';
+import IDashboard from './interfaces/IDashboard';
+import { eventSchema } from './EventSchema';
+
+const FREE_TEXT_FIELDS = ['message', 'description', 'comment'];
+
+export default class EventEmitter {
+  constructor(private readonly dashboard: IDashboard) {}
+
+  public emit(event: IEvent): boolean {
+    if (!this.validate(event)) {
+      return false;
+    }
+
+    const sanitized = this.redact(event);
+    this.dashboard.send(sanitized);
+    return true;
+  }
+
+  private validate(event: IEvent): boolean {
+    if (eventSchema.required.some((key) => !(key in event))) {
+      return false;
+    }
+
+    if (typeof event.event !== 'string') return false;
+    if (typeof event.version !== 'string') return false;
+    if (typeof event.owner !== 'string') return false;
+    if (typeof event.timestamp !== 'string') return false;
+    if (event.properties && typeof event.properties !== 'object') return false;
+
+    return true;
+  }
+
+  private redact(event: IEvent): IEvent {
+    const properties = { ...(event.properties || {}) };
+
+    FREE_TEXT_FIELDS.forEach((field) => {
+      if (typeof properties[field] === 'string') {
+        properties[field] = '[REDACTED]';
+      }
+    });
+
+    return { ...event, properties };
+  }
+}

--- a/src/modules/events/EventSchema.ts
+++ b/src/modules/events/EventSchema.ts
@@ -1,0 +1,17 @@
+export const EVENT_SCHEMA_VERSION = '1.0.0';
+export const EVENT_SCHEMA_OWNER = 'data-team';
+
+export const eventSchema = {
+  type: 'object',
+  required: ['event', 'version', 'owner', 'timestamp'],
+  properties: {
+    event: { type: 'string' },
+    version: { type: 'string' },
+    owner: { type: 'string' },
+    timestamp: { type: 'string' },
+    properties: { type: 'object', additionalProperties: true },
+  },
+  additionalProperties: false,
+} as const;
+
+export default eventSchema;

--- a/src/modules/events/interfaces/IDashboard.ts
+++ b/src/modules/events/interfaces/IDashboard.ts
@@ -1,0 +1,5 @@
+import IEvent from './IEvent';
+
+export default interface IDashboard {
+  send(event: IEvent): void;
+}

--- a/src/modules/events/interfaces/IEvent.ts
+++ b/src/modules/events/interfaces/IEvent.ts
@@ -1,0 +1,7 @@
+export default interface IEvent {
+  event: string;
+  version: string;
+  owner: string;
+  timestamp: string;
+  properties?: { [key: string]: any };
+}

--- a/tests/modules/EventEmitter.test.ts
+++ b/tests/modules/EventEmitter.test.ts
@@ -1,0 +1,45 @@
+import EventEmitter from '../../src/modules/events/EventEmitter';
+import IDashboard from '../../src/modules/events/interfaces/IDashboard';
+import IEvent from '../../src/modules/events/interfaces/IEvent';
+
+class MockDashboard implements IDashboard {
+  public events: IEvent[] = [];
+
+  send(event: IEvent): void {
+    this.events.push(event);
+  }
+}
+
+describe('EventEmitter', () => {
+  it('redacts free-text fields', () => {
+    const dashboard = new MockDashboard();
+    const emitter = new EventEmitter(dashboard);
+    const event: IEvent = {
+      event: 'test',
+      version: '1.0.0',
+      owner: 'team',
+      timestamp: new Date().toISOString(),
+      properties: { message: 'secret' },
+    };
+
+    emitter.emit(event);
+
+    expect(dashboard.events).toHaveLength(1);
+    expect(dashboard.events[0].properties?.message).toBe('[REDACTED]');
+  });
+
+  it('blocks invalid events', () => {
+    const dashboard = new MockDashboard();
+    const emitter = new EventEmitter(dashboard);
+    const invalid: any = {
+      event: 'test',
+      owner: 'team',
+      timestamp: new Date().toISOString(),
+    };
+
+    const result = emitter.emit(invalid);
+
+    expect(result).toBe(false);
+    expect(dashboard.events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add central event schema with version and owner metadata
- implement event emitter validating events and redacting free-text fields
- test that only valid, redacted events reach dashboards

## Testing
- `npm install` *(fails: node-sass build error)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a37632c832895baea1e6d6eb073