### PR TITLE
feat: add invariant and error handling utilities

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,39 @@
+export enum ErrorCode {
+  UNKNOWN = 'unknown',
+  MISSING_DATA = 'missing_data',
+  INVALID_STATE = 'invalid_state',
+}
+
+export const errorMessages: Record<ErrorCode, string> = {
+  [ErrorCode.UNKNOWN]: 'An unknown error occurred',
+  [ErrorCode.MISSING_DATA]: 'Required data is missing',
+  [ErrorCode.INVALID_STATE]: 'Application is in an invalid state',
+};
+
+export class DomainError extends Error {
+  public readonly code: ErrorCode;
+
+  constructor(code: ErrorCode, message?: string) {
+    super(message ?? errorMessages[code]);
+    this.code = code;
+    this.name = 'DomainError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function invariant(condition: any, code: ErrorCode, message?: string): asserts condition {
+  if (!condition) {
+    throw new DomainError(code, message);
+  }
+}
+
+export function handleError(err: unknown): { code: ErrorCode; message: string } {
+  if (err instanceof DomainError) {
+    return {
+      code: err.code,
+      message: errorMessages[err.code] ?? err.message,
+    };
+  }
+
+  return { code: ErrorCode.UNKNOWN, message: errorMessages[ErrorCode.UNKNOWN] };
+}

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,0 +1,31 @@
+import { DomainError, ErrorCode, errorMessages, handleError, invariant } from '../../src/utils/errors';
+
+describe('invariant', () => {
+  it('does nothing when condition is true', () => {
+    expect(() => invariant(true, ErrorCode.MISSING_DATA)).not.toThrow();
+  });
+
+  it('throws DomainError with provided code', () => {
+    expect(() => invariant(false, ErrorCode.MISSING_DATA)).toThrow(DomainError);
+  });
+});
+
+describe('handleError', () => {
+  it('maps DomainError to friendly message', () => {
+    const err = new DomainError(ErrorCode.MISSING_DATA);
+    const handled = handleError(err);
+    expect(handled).toEqual({ code: ErrorCode.MISSING_DATA, message: errorMessages[ErrorCode.MISSING_DATA] });
+  });
+
+  it('maps another DomainError code to correct message', () => {
+    const err = new DomainError(ErrorCode.INVALID_STATE);
+    const handled = handleError(err);
+    expect(handled).toEqual({ code: ErrorCode.INVALID_STATE, message: errorMessages[ErrorCode.INVALID_STATE] });
+  });
+
+  it('converts unknown error to unknown code and message', () => {
+    const err = new Error('boom');
+    const handled = handleError(err);
+    expect(handled).toEqual({ code: ErrorCode.UNKNOWN, message: errorMessages[ErrorCode.UNKNOWN] });
+  });
+});


### PR DESCRIPTION
## Summary
- add `invariant` utility that throws typed `DomainError`
- implement global error handler that maps error codes to messages and wraps crashes
- test error utility and handler for expected messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a3850f88328bf14679c6fda7121