### PR TITLE
Add coach mark management with analytics and persistence

### DIFF
--- a/src/modules/coachmarks/CoachMarks.ts
+++ b/src/modules/coachmarks/CoachMarks.ts
@@ -1,0 +1,101 @@
+import { injectable } from 'inversify';
+import StorageLike from '../../utils/StorageLike';
+import MemoryStorage from '../../utils/MemoryStorage';
+
+export interface CoachMark {
+  id: string;
+  criteria: () => boolean;
+  frequencyCap: number;
+}
+
+export interface CoachMarkAnalytics {
+  impressions: number;
+  clicks: number;
+  dismissals: number;
+}
+
+@injectable()
+export default class CoachMarks {
+  private storage: StorageLike;
+
+  private analyticsCache: Record<string, CoachMarkAnalytics> = {};
+
+  constructor(storage: StorageLike = new MemoryStorage()) {
+    this.storage = storage;
+  }
+
+  private analyticsKey(id: string): string {
+    return `coachmarks:analytics:${id}`;
+  }
+
+  private dontShowKey(id: string): string {
+    return `coachmarks:dont:${id}`;
+  }
+
+  private loadAnalytics(id: string): CoachMarkAnalytics {
+    if (!this.analyticsCache[id]) {
+      const stored = this.storage.getItem(this.analyticsKey(id));
+      this.analyticsCache[id] = stored ? JSON.parse(stored) : {
+        impressions: 0,
+        clicks: 0,
+        dismissals: 0,
+      };
+    }
+
+    return this.analyticsCache[id];
+  }
+
+  private saveAnalytics(id: string): void {
+    this.storage.setItem(this.analyticsKey(id), JSON.stringify(this.loadAnalytics(id)));
+  }
+
+  public shouldShow(mark: CoachMark): boolean {
+    if (!mark.criteria()) {
+      return false;
+    }
+
+    if (this.storage.getItem(this.dontShowKey(mark.id))) {
+      return false;
+    }
+
+    const { impressions } = this.loadAnalytics(mark.id);
+    return impressions < mark.frequencyCap;
+  }
+
+  public markShown(id: string): void {
+    const data = this.loadAnalytics(id);
+    data.impressions += 1;
+    this.saveAnalytics(id);
+  }
+
+  public trackClick(id: string): void {
+    const data = this.loadAnalytics(id);
+    data.clicks += 1;
+    this.saveAnalytics(id);
+  }
+
+  public trackDismiss(id: string): void {
+    const data = this.loadAnalytics(id);
+    data.dismissals += 1;
+    this.saveAnalytics(id);
+  }
+
+  public dontShowAgain(id: string): void {
+    this.storage.setItem(this.dontShowKey(id), '1');
+  }
+
+  public getAnalytics(id: string): CoachMarkAnalytics {
+    return this.loadAnalytics(id);
+  }
+
+  public removeLowPerforming(marks: CoachMark[], threshold: number): CoachMark[] {
+    return marks.filter((mark) => {
+      const data = this.loadAnalytics(mark.id);
+      if (data.impressions === 0) {
+        return true;
+      }
+      const ctr = data.clicks / data.impressions;
+      return ctr >= threshold;
+    });
+  }
+}

--- a/src/utils/MemoryStorage.ts
+++ b/src/utils/MemoryStorage.ts
@@ -1,0 +1,13 @@
+import StorageLike from './StorageLike';
+
+export default class MemoryStorage implements StorageLike {
+  private data: Map<string, string> = new Map();
+
+  public getItem(key: string): string | null {
+    return this.data.has(key) ? this.data.get(key) as string : null;
+  }
+
+  public setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}

--- a/src/utils/StorageLike.ts
+++ b/src/utils/StorageLike.ts
@@ -1,0 +1,4 @@
+export default interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}

--- a/tests/modules/CoachMarks.test.ts
+++ b/tests/modules/CoachMarks.test.ts
@@ -1,0 +1,62 @@
+import CoachMarks, { CoachMark } from '../../src/modules/coachmarks/CoachMarks';
+import MemoryStorage from '../../src/utils/MemoryStorage';
+
+describe('CoachMarks module', () => {
+  const criteriaTrue = () => true;
+
+  it('shows coach mark based on discovery criteria and frequency cap', () => {
+    const storage = new MemoryStorage();
+    const marks = new CoachMarks(storage);
+    const mark: CoachMark = { id: 'a', criteria: criteriaTrue, frequencyCap: 2 };
+
+    expect(marks.shouldShow(mark)).toBe(true);
+    marks.markShown('a');
+    expect(marks.shouldShow(mark)).toBe(true);
+    marks.markShown('a');
+    expect(marks.shouldShow(mark)).toBe(false);
+  });
+
+  it('persists "don\'t show again" across instances', () => {
+    const storage = new MemoryStorage();
+    const mark: CoachMark = { id: 'a', criteria: criteriaTrue, frequencyCap: 5 };
+    const first = new CoachMarks(storage);
+    first.dontShowAgain('a');
+    expect(first.shouldShow(mark)).toBe(false);
+
+    const second = new CoachMarks(storage);
+    expect(second.shouldShow(mark)).toBe(false);
+  });
+
+  it('tracks analytics for impressions, clicks and dismissals', () => {
+    const storage = new MemoryStorage();
+    const marks = new CoachMarks(storage);
+
+    marks.markShown('a');
+    marks.trackClick('a');
+    marks.trackDismiss('a');
+
+    expect(marks.getAnalytics('a')).toStrictEqual({
+      impressions: 1,
+      clicks: 1,
+      dismissals: 1,
+    });
+  });
+
+  it('removes low-performing hints based on CTR threshold', () => {
+    const storage = new MemoryStorage();
+    const marks = new CoachMarks(storage);
+    const hints: CoachMark[] = [
+      { id: 'a', criteria: criteriaTrue, frequencyCap: 5 },
+      { id: 'b', criteria: criteriaTrue, frequencyCap: 5 },
+    ];
+
+    marks.markShown('a');
+    marks.trackClick('a');
+
+    marks.markShown('b');
+
+    const filtered = marks.removeLowPerforming(hints, 0.5);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('a');
+  });
+});


### PR DESCRIPTION
## Summary
- add CoachMarks module to manage discovery-based hints with frequency caps
- persist "don't show again" decisions and track impressions, clicks, and dismissals
- filter low-performing hints based on click-through rate

## Testing
- `yarn lint && echo 'lint ok'`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a39f16483288e007ef0ed92e54a