### PR TITLE
feat: add versioned local cache with migration support

### DIFF
--- a/src/utils/LocalStorageCache.ts
+++ b/src/utils/LocalStorageCache.ts
@@ -1,0 +1,98 @@
+import ILogger from '../modules/logger/interfaces/ILogger';
+import ConsoleLogger from '../modules/logger/ConsoleLogger';
+
+export type MigrationFunc<T> = (data: any) => T;
+
+/**
+ * Utility for storing versioned data in localStorage with migrations.
+ */
+export default class LocalStorageCache<T> {
+  protected readonly key: string;
+
+  protected readonly version: number;
+
+  protected readonly defaultValue: T;
+
+  protected readonly migrations: { [version: number]: MigrationFunc<T> };
+
+  protected readonly logger: ILogger;
+
+  constructor(
+    key: string,
+    version: number,
+    defaultValue: T,
+    migrations: { [version: number]: MigrationFunc<T> } = {},
+    logger: ILogger = new ConsoleLogger(),
+  ) {
+    this.key = key;
+    this.version = version;
+    this.defaultValue = defaultValue;
+    this.migrations = migrations;
+    this.logger = logger;
+  }
+
+  /**
+   * Load data from storage and run migrations if necessary.
+   */
+  public load(): T {
+    const raw = globalThis.localStorage?.getItem(this.key);
+    if (!raw) {
+      return this.defaultValue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      const storedVersion = parsed.v ?? 0;
+      let data = parsed.data as T;
+
+      if (storedVersion !== this.version) {
+        try {
+          data = this.migrate(data, storedVersion);
+        } catch (e) {
+          this.logger.error(`Failed to migrate cache "${this.key}"`, e);
+          this.reset();
+          return this.defaultValue;
+        }
+      }
+
+      this.save(data);
+      return data;
+    } catch (e) {
+      this.logger.error(`Failed to read cache "${this.key}"`, e);
+      this.reset();
+      return this.defaultValue;
+    }
+  }
+
+  /**
+   * Save data with current version.
+   */
+  public save(data: T): void {
+    globalThis.localStorage?.setItem(
+      this.key,
+      JSON.stringify({ v: this.version, data }),
+    );
+  }
+
+  /**
+   * Remove data from storage.
+   */
+  public reset(): void {
+    globalThis.localStorage?.removeItem(this.key);
+  }
+
+  protected migrate(data: T, from: number): T {
+    let current = from;
+    let result: any = data;
+    while (current < this.version) {
+      const fn = this.migrations[current];
+      if (!fn) {
+        throw new Error(`Missing migration for version ${current}`);
+      }
+      result = fn(result);
+      current += 1;
+    }
+    return result as T;
+  }
+}
+

--- a/tests/utils/LocalStorageCache.test.ts
+++ b/tests/utils/LocalStorageCache.test.ts
@@ -1,0 +1,73 @@
+import LocalStorageCache from '../../src/utils/LocalStorageCache';
+
+class MemoryStorage {
+  private store: { [key: string]: string } = {};
+
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+
+  clear(): void {
+    this.store = {};
+  }
+}
+
+describe('LocalStorageCache', () => {
+  beforeEach(() => {
+    (global as any).localStorage = new MemoryStorage() as any;
+  });
+
+  it('saves version with data', () => {
+    const cache = new LocalStorageCache('t', 1, { a: 1 });
+    cache.save({ a: 2 });
+
+    const raw = (global as any).localStorage.getItem('t');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toStrictEqual({ v: 1, data: { a: 2 } });
+  });
+
+  it('migrates data to new version', () => {
+    (global as any).localStorage.setItem('t', JSON.stringify({ v: 1, data: { a: 1 } }));
+    const cache = new LocalStorageCache('t', 2, { a: 0 }, {
+      1: (data: any) => ({ ...data, b: 2 }),
+    });
+
+    const data = cache.load();
+
+    expect(data).toStrictEqual({ a: 1, b: 2 });
+    const stored = JSON.parse((global as any).localStorage.getItem('t') as string);
+    expect(stored.v).toBe(2);
+  });
+
+  it('resets and logs on migration failure', () => {
+    const logger = {
+      error: jest.fn(),
+      log: jest.fn(),
+      warning: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    } as any;
+
+    (global as any).localStorage.setItem('t', JSON.stringify({ v: 1, data: { a: 1 } }));
+    const cache = new LocalStorageCache('t', 2, { a: 0 }, {
+      1: () => { throw new Error('fail'); },
+    }, logger);
+
+    const data = cache.load();
+
+    expect(data).toStrictEqual({ a: 0 });
+    expect((global as any).localStorage.getItem('t')).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add LocalStorageCache utility with versioned data and migrations
- reset cache and emit telemetry on migration failure
- test schema bumps and migration failure handling

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a391e50832894d4476bcba0a2a6