### PR TITLE
feat: add canary middleware and banner

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,11 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import canaryMiddleware from './canaryMiddleware';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+  run(app: any, server: WebpackDevServer, compiler: Compiler): void {
+    app.use(canaryMiddleware);
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/modules/server/canaryMiddleware.ts
+++ b/src/modules/server/canaryMiddleware.ts
@@ -1,0 +1,14 @@
+import { hasCanaryFromHeaders } from '../../utils/CanaryUtils';
+
+export default function canaryMiddleware(req: any, _res: any, next: any): void {
+  try {
+    if (req && req.headers && hasCanaryFromHeaders(req.headers) && typeof req.url === 'string' && !req.url.startsWith('/canary')) {
+      req.url = `/canary${req.url}`;
+    }
+  } catch (e) {
+    // ignore parsing errors
+  }
+  if (typeof next === 'function') {
+    next();
+  }
+}

--- a/src/pages/admin/index.ejs
+++ b/src/pages/admin/index.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Canary Admin</title>
+</head>
+<body>
+  <h1>Canary Session</h1>
+  <button id="enable-canary">Enable Canary</button>
+  <button id="disable-canary">Disable Canary</button>
+  <script>
+    function setCanary(flag) {
+      document.cookie = 'canary=' + (flag ? 'true' : '') + ';path=/';
+    }
+    document.getElementById('enable-canary').addEventListener('click', function () { setCanary(true); });
+    document.getElementById('disable-canary').addEventListener('click', function () { setCanary(false); });
+  </script>
+</body>
+</html>

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,7 +1,19 @@
+import { isCanaryClient } from '../../utils/CanaryUtils';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
+    });
+  }
+
+  if (isCanaryClient()) {
+    const banner = document.createElement('div');
+    banner.id = 'canary-banner';
+    banner.innerHTML = 'Canary release — <a href="/feedback" target="_blank">Send feedback</a>';
+    banner.style.cssText = 'position:fixed;top:0;left:0;width:100%;background:yellow;color:black;padding:8px;text-align:center;z-index:1000;';
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.prepend(banner);
     });
   }
 })();

--- a/src/templates/_common/styles/index.scss
+++ b/src/templates/_common/styles/index.scss
@@ -1,1 +1,18 @@
 @import "~normalize.css";
+
+#canary-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: yellow;
+  color: black;
+  padding: 8px;
+  text-align: center;
+  z-index: 1000;
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}

--- a/src/utils/CanaryUtils.ts
+++ b/src/utils/CanaryUtils.ts
@@ -1,0 +1,23 @@
+export function hasCanaryFromHeaders(headers: Record<string, string | string[] | undefined>): boolean {
+  const header = headers['x-canary'];
+  if (typeof header === 'string' && header.toLowerCase() === 'true') {
+    return true;
+  }
+  const cookie = headers['cookie'];
+  if (typeof cookie === 'string') {
+    return cookie.split(';').map((c) => c.trim()).some((c) => c === 'canary=true');
+  }
+  return false;
+}
+
+export function isCanaryClient(): boolean {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  return document.cookie.split(';').map((c) => c.trim()).includes('canary=true');
+}
+
+export function setCanaryCookie(enabled: boolean): void {
+  const expires = enabled ? '' : 'expires=Thu, 01 Jan 1970 00:00:00 GMT;';
+  document.cookie = `canary=${enabled ? 'true' : ''};path=/;${expires}`;
+}

--- a/tests/modules/CanaryMiddleware.test.ts
+++ b/tests/modules/CanaryMiddleware.test.ts
@@ -1,0 +1,23 @@
+import canaryMiddleware from '../../src/modules/server/canaryMiddleware';
+
+describe('canaryMiddleware', () => {
+  it('prefixes url when canary cookie is set', () => {
+    const req: any = { headers: { cookie: 'foo=bar; canary=true' }, url: '/test' };
+    const next = jest.fn();
+    canaryMiddleware(req, {}, next);
+    expect(req.url).toBe('/canary/test');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('prefixes url when canary header is present', () => {
+    const req: any = { headers: { 'x-canary': 'true' }, url: '/home' };
+    canaryMiddleware(req, {}, () => {});
+    expect(req.url).toBe('/canary/home');
+  });
+
+  it('does nothing when flag absent', () => {
+    const req: any = { headers: {}, url: '/root' };
+    canaryMiddleware(req, {}, () => {});
+    expect(req.url).toBe('/root');
+  });
+});


### PR DESCRIPTION
## Summary
- route requests with canary flag to a canary path via server middleware
- allow toggling canary cookie through a simple admin page
- show canary banner with feedback link when flag is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a3b3e0c83288bb41494ec2a3c70