### PR TITLE
feat: enhance code blocks

### DIFF
--- a/src/templates/_common/scripts/code-block.ts
+++ b/src/templates/_common/scripts/code-block.ts
@@ -1,0 +1,100 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function loadHighlightJs(): Promise<any> {
+  return new Promise((resolve) => {
+    const w = window as any;
+    if (w.hljs) {
+      resolve(w.hljs);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js';
+    script.addEventListener('load', () => resolve(w.hljs));
+    document.head.appendChild(script);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css';
+    document.head.appendChild(link);
+  });
+}
+
+function buildLines(html: string): string {
+  return html
+    .trimEnd()
+    .split('\n')
+    .map((line) => `<span class="code-block__line">${line || '&nbsp;'}</span>`)
+    .join('\n');
+}
+
+function enhanceBlock(hljs: any, code: HTMLElement): void {
+  const pre = code.parentElement as HTMLElement;
+  if (!pre) {
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'code-block code-block--numbered';
+  pre.parentNode?.insertBefore(wrapper, pre);
+  wrapper.appendChild(pre);
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'code-block__toolbar';
+  wrapper.insertBefore(toolbar, pre);
+
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'code-block__copy';
+  copyBtn.textContent = 'Copy';
+  toolbar.appendChild(copyBtn);
+
+  const linesBtn = document.createElement('button');
+  linesBtn.type = 'button';
+  linesBtn.className = 'code-block__lines-toggle';
+  linesBtn.textContent = 'Line numbers';
+  toolbar.appendChild(linesBtn);
+
+  const toast = document.createElement('div');
+  toast.className = 'code-block__toast';
+  toast.textContent = 'Copied!';
+  wrapper.appendChild(toast);
+
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(code.textContent || '');
+    toast.classList.add('code-block__toast--visible');
+    setTimeout(() => toast.classList.remove('code-block__toast--visible'), 2000);
+  });
+
+  linesBtn.addEventListener('click', () => {
+    wrapper.classList.toggle('code-block--numbered');
+  });
+
+  const override = code.dataset.language || (code.className.match(/language-(\w+)/) || [])[1];
+  const source = code.textContent || '';
+  const result = override
+    ? hljs.highlight(source, { language: override })
+    : hljs.highlightAuto(source);
+
+  code.innerHTML = buildLines(result.value);
+
+  if (result.language) {
+    code.classList.add(`language-${result.language}`);
+    pre.setAttribute('data-language', result.language);
+  }
+
+  pre.classList.add('code-block__pre');
+  pre.setAttribute('tabindex', '0');
+  pre.setAttribute('role', 'region');
+  pre.setAttribute('aria-label', `Code block${result.language ? ` (${result.language})` : ''}`);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadHighlightJs().then((hljs) => {
+    document.querySelectorAll<HTMLElement>('pre code').forEach((block) => {
+      enhanceBlock(hljs, block);
+    });
+  });
+});
+
+export {};

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,3 +1,5 @@
+import './code-block';
+
 (() => {
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {

--- a/src/templates/_common/styles/index.scss
+++ b/src/templates/_common/styles/index.scss
@@ -1,1 +1,64 @@
 @import "~normalize.css";
+
+.code-block {
+  position: relative;
+  margin: 1rem 0;
+}
+
+.code-block__toolbar {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-bottom: 0.25rem;
+}
+
+.code-block__copy,
+.code-block__lines-toggle {
+  font-size: 0.75rem;
+}
+
+.code-block__pre {
+  overflow-x: auto;
+}
+
+.code-block__pre:focus {
+  outline: 2px solid #aaa;
+}
+
+.code-block__line {
+  display: block;
+}
+
+.code-block--numbered code {
+  counter-reset: line;
+}
+
+.code-block--numbered .code-block__line {
+  counter-increment: line;
+}
+
+.code-block--numbered .code-block__line::before {
+  content: counter(line);
+  display: inline-block;
+  width: 2em;
+  margin-right: 1em;
+  color: #888;
+  text-align: right;
+}
+
+.code-block__toast {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #333;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+}
+
+.code-block__toast--visible {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- load highlight.js dynamically for automatic code language detection with optional manual override
- add copy button with toast, line number toggle, and accessible horizontal scrolling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a3ca94c8328bc5d5f970a6f6bd9