### PR TITLE
feat: add JSON Patch support with conflict handling

### DIFF
--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,27 @@
+import express, { Application } from 'express';
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { Application } from 'express';
+import { applyPatch, Operation } from '../../utils/jsonPatch';
 
 export default class Server {
+  private data: any = {};
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.use(express.json());
+
+    app.get('/api/data', (req, res) => {
+      res.json(this.data);
+    });
+
+    app.patch('/api/data', (req, res) => {
+      const operations: Operation[] = req.body;
+      try {
+        this.data = applyPatch(this.data, operations);
+        res.json(this.data);
+      } catch (err) {
+        res.status(409).json({ message: (err as Error).message });
+      }
+    });
   }
 }

--- a/src/utils/jsonPatch.ts
+++ b/src/utils/jsonPatch.ts
@@ -1,0 +1,81 @@
+export interface Operation {
+  op: 'add' | 'remove' | 'replace';
+  path: string;
+  value?: any;
+}
+
+function buildPath(base: string, key: string | number): string {
+  const segment = encodeURIComponent(String(key));
+  return `${base}/${segment}`.replace(/\/+/g, '/');
+}
+
+export function generatePatch(oldObj: any, newObj: any, base = ''): Operation[] {
+  const patch: Operation[] = [];
+
+  // removals and replacements
+  Object.keys(oldObj).forEach((key) => {
+    const oldVal = oldObj[key];
+    if (!(key in newObj)) {
+      patch.push({ op: 'remove', path: buildPath(base, key) });
+    } else {
+      const newVal = newObj[key];
+      if (typeof oldVal === 'object' && oldVal !== null && typeof newVal === 'object' && newVal !== null) {
+        patch.push(...generatePatch(oldVal, newVal, buildPath(base, key)));
+      } else if (oldVal !== newVal) {
+        patch.push({ op: 'replace', path: buildPath(base, key), value: newVal });
+      }
+    }
+  });
+
+  // additions
+  Object.keys(newObj).forEach((key) => {
+    if (!(key in oldObj)) {
+      patch.push({ op: 'add', path: buildPath(base, key), value: newObj[key] });
+    }
+  });
+
+  return patch;
+}
+
+function getParent(target: any, path: string): { parent: any; key: string } {
+  const segments = path.replace(/^\//, '').split('/').map((s) => decodeURIComponent(s));
+  const key = segments.pop() as string;
+  let parent = target;
+  for (const seg of segments) {
+    if (!(seg in parent)) {
+      throw new Error(`Conflict at /${segments.join('/')}`);
+    }
+    parent = parent[seg];
+  }
+  return { parent, key };
+}
+
+export function applyPatch(target: any, operations: Operation[]): any {
+  const clone = JSON.parse(JSON.stringify(target));
+
+  operations.forEach((op) => {
+    const { parent, key } = getParent(clone, op.path);
+
+    switch (op.op) {
+      case 'add':
+        parent[key] = op.value;
+        break;
+      case 'replace':
+        if (!(key in parent)) {
+          throw new Error(`Conflict at ${op.path}`);
+        }
+        parent[key] = op.value;
+        break;
+      case 'remove':
+        if (!(key in parent)) {
+          throw new Error(`Conflict at ${op.path}`);
+        }
+        delete parent[key];
+        break;
+      default:
+        throw new Error(`Unsupported operation: ${op.op}`);
+    }
+  });
+
+  return clone;
+}

--- a/tests/modules/JsonPatch.test.ts
+++ b/tests/modules/JsonPatch.test.ts
@@ -1,0 +1,55 @@
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+import Server from '../../src/modules/server/Server';
+import { generatePatch, Operation } from '../../src/utils/jsonPatch';
+
+describe('JSON Patch integration', () => {
+  test('generate minimal patch', () => {
+    const original: Record<string, number> = {};
+    for (let i = 0; i < 20; i += 1) {
+      original[`k${i}`] = i;
+    }
+    const updated = { ...original, k0: 99 };
+    const patch = generatePatch(original, updated);
+
+    expect(patch).toEqual([{ op: 'replace', path: '/k0', value: 99 }]);
+    expect(JSON.stringify(patch).length).toBeLessThan(JSON.stringify(updated).length);
+  });
+
+  test('server applies patches and detects conflicts', async () => {
+    const app = express();
+    const server = new Server();
+    // @ts-ignore
+    server.run(app, {} as any, {} as any);
+    const httpServer = app.listen();
+    const { port } = httpServer.address() as AddressInfo;
+
+    const send = (ops: Operation[]): Promise<{ status: number; body: any }> => new Promise((resolve, reject) => {
+      const req = http.request({
+        method: 'PATCH',
+        port,
+        path: '/api/data',
+        headers: { 'Content-Type': 'application/json' },
+      }, (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          resolve({ status: res.statusCode || 0, body: data ? JSON.parse(data) : undefined });
+        });
+      });
+      req.on('error', reject);
+      req.write(JSON.stringify(ops));
+      req.end();
+    });
+
+    const ok = await send([{ op: 'add', path: '/count', value: 1 }]);
+    expect(ok).toEqual({ status: 200, body: { count: 1 } });
+
+    const conflict = await send([{ op: 'replace', path: '/missing', value: 1 }]);
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.message).toMatch(/Conflict/);
+
+    httpServer.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add in-memory server endpoint for RFC 6902 JSON Patch updates
- provide utility to generate and apply JSON Patch operations with conflict detection
- add tests ensuring minimal patch generation and conflict handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a3e82448328800d0758ca64c57a