### PR TITLE
feat: add worker pool with priority queue

### DIFF
--- a/src/utils/PriorityTaskQueue.ts
+++ b/src/utils/PriorityTaskQueue.ts
@@ -1,0 +1,20 @@
+export interface Prioritized {
+  priority: number;
+}
+
+export default class PriorityTaskQueue<T extends Prioritized> {
+  private items: T[] = [];
+
+  enqueue(item: T): void {
+    this.items.push(item);
+    this.items.sort((a, b) => b.priority - a.priority);
+  }
+
+  dequeue(): T | undefined {
+    return this.items.shift();
+  }
+
+  get length(): number {
+    return this.items.length;
+  }
+}

--- a/src/utils/WorkerPool.ts
+++ b/src/utils/WorkerPool.ts
@@ -1,0 +1,129 @@
+import PriorityTaskQueue, { Prioritized } from './PriorityTaskQueue';
+
+declare const require: any;
+
+interface Task extends Prioritized {
+  id: number;
+  type: string;
+  payload: any;
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+}
+
+interface WorkerPoolOptions {
+  size: number;
+  maxQueueSize?: number;
+  onBackpressure?: () => void;
+}
+
+type WorkerType = any;
+
+export default class WorkerPool {
+  private workers: WorkerType[] = [];
+
+  private busy: Map<WorkerType, Task> = new Map();
+
+  private queue = new PriorityTaskQueue<Task>();
+
+  private nextId = 0;
+
+  private maxQueueSize: number;
+
+  private onBackpressure?: () => void;
+
+  constructor(options: WorkerPoolOptions) {
+    this.maxQueueSize = options.maxQueueSize ?? Infinity;
+    this.onBackpressure = options.onBackpressure;
+
+    for (let i = 0; i < options.size; i += 1) {
+      const worker = this.createWorker();
+      this.bindWorker(worker);
+      this.workers.push(worker);
+    }
+  }
+
+  private createWorker(): WorkerType {
+    if (typeof window === 'undefined') {
+      const path = require('path');
+      const { Worker } = require('worker_threads');
+      return new Worker(path.resolve(__dirname, './task.worker.ts'), {
+        execArgv: ['-r', 'ts-node/register'],
+      });
+    }
+
+    return new Worker('./task.worker.ts');
+  }
+
+  private bindWorker(worker: WorkerType): void {
+    const handle = (msg: any) => {
+      const task = this.busy.get(worker);
+      if (!task) return;
+      const { id, result, error } = msg;
+      if (task.id === id) {
+        if (error) task.reject(new Error(error));
+        else task.resolve(result);
+        this.busy.delete(worker);
+        this.runNext();
+      }
+    };
+
+    if (typeof worker.on === 'function') {
+      worker.on('message', handle);
+      worker.on('error', (err: any) => {
+        const task = this.busy.get(worker);
+        if (task) task.reject(err);
+        this.busy.delete(worker);
+        this.runNext();
+      });
+    } else {
+      const webWorker = worker as any;
+      webWorker.onmessage = (e: any) => handle(e.data);
+      webWorker.onerror = (err: any) => {
+        const task = this.busy.get(worker);
+        if (task) task.reject(err as Error);
+        this.busy.delete(worker);
+        this.runNext();
+      };
+    }
+  }
+
+  runTask(type: string, payload: any, priority = 0): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.nextId += 1;
+      const task: Task = {
+        id: this.nextId,
+        type,
+        payload,
+        priority,
+        resolve,
+        reject,
+      };
+      this.queue.enqueue(task);
+      if (this.queue.length > this.maxQueueSize) {
+        this.onBackpressure?.();
+      }
+      this.runNext();
+    });
+  }
+
+  private runNext(): void {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const worker = this.workers.find((w) => !this.busy.has(w));
+      if (!worker) break;
+      const task = this.queue.dequeue();
+      if (!task) break;
+      this.busy.set(worker, task);
+      worker.postMessage({ id: task.id, type: task.type, payload: task.payload });
+    }
+  }
+
+  terminate(): void {
+    this.workers.forEach((worker) => {
+      if (typeof worker.terminate === 'function') {
+        worker.terminate();
+      }
+    });
+    this.workers = [];
+  }
+}

--- a/src/utils/task.worker.ts
+++ b/src/utils/task.worker.ts
@@ -1,0 +1,46 @@
+/* eslint-disable no-restricted-globals */
+let post: (msg: any) => void;
+
+function fibonacci(n: number): number {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+function handle(message: any): void {
+  const { id, type, payload } = message;
+  try {
+    let result: any;
+    switch (type) {
+      case 'parse':
+        result = JSON.parse(payload);
+        break;
+      case 'encode':
+        if (typeof Buffer !== 'undefined') {
+          result = Buffer.from(payload).toString('base64');
+        } else {
+          // @ts-ignore
+          result = btoa(payload);
+        }
+        break;
+      case 'heavy':
+        result = fibonacci(payload);
+        break;
+      default:
+        throw new Error(`Unknown task type: ${type}`);
+    }
+    post({ id, result });
+  } catch (e) {
+    post({ id, error: (e as Error).message });
+  }
+}
+
+// Determine environment
+if (typeof self !== 'undefined' && typeof (self as any).postMessage === 'function') {
+  (self as any).onmessage = (e: MessageEvent) => handle(e.data);
+  post = (msg) => (self as any).postMessage(msg);
+} else {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { parentPort } = require('worker_threads');
+  parentPort.on('message', handle);
+  post = (msg) => parentPort.postMessage(msg);
+}

--- a/tests/utils/PriorityTaskQueue.test.ts
+++ b/tests/utils/PriorityTaskQueue.test.ts
@@ -1,0 +1,13 @@
+import PriorityTaskQueue from '../../src/utils/PriorityTaskQueue';
+
+describe('PriorityTaskQueue', () => {
+  it('dequeues items by priority', () => {
+    const queue = new PriorityTaskQueue<{ priority: number; value: string }>();
+    queue.enqueue({ priority: 1, value: 'low' });
+    queue.enqueue({ priority: 10, value: 'high' });
+    queue.enqueue({ priority: 5, value: 'medium' });
+    expect(queue.dequeue()?.value).toBe('high');
+    expect(queue.dequeue()?.value).toBe('medium');
+    expect(queue.dequeue()?.value).toBe('low');
+  });
+});

--- a/tests/utils/WorkerPool.test.ts
+++ b/tests/utils/WorkerPool.test.ts
@@ -1,0 +1,35 @@
+import WorkerPool from '../../src/utils/WorkerPool';
+
+describe('WorkerPool', () => {
+  it('processes tasks in priority order', async () => {
+    const pool = new WorkerPool({ size: 1 });
+    const order: string[] = [];
+    const t1 = pool.runTask('heavy', 20, 1).then(() => order.push('low'));
+    const t2 = pool.runTask('parse', '"{}"', 10).then(() => order.push('high'));
+    const t3 = pool.runTask('encode', 'data', 5).then(() => order.push('medium'));
+    await Promise.all([t1, t2, t3]);
+    expect(order).toEqual(['low', 'high', 'medium']);
+    pool.terminate();
+  });
+
+  it('signals backpressure when queue saturated', async () => {
+    const onBackpressure = jest.fn();
+    const pool = new WorkerPool({ size: 1, maxQueueSize: 1, onBackpressure });
+    pool.runTask('parse', '"1"');
+    pool.runTask('parse', '"2"');
+    pool.runTask('parse', '"3"');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onBackpressure).toHaveBeenCalled();
+    pool.terminate();
+  });
+
+  it('executes heavy tasks without blocking main thread', async () => {
+    const pool = new WorkerPool({ size: 1 });
+    let flag = false;
+    const heavy = pool.runTask('heavy', 35);
+    setTimeout(() => { flag = true; }, 0);
+    await heavy;
+    expect(flag).toBe(true);
+    pool.terminate();
+  });
+});


### PR DESCRIPTION
## Summary
- add shared worker pool using priority task queue
- signal UI backpressure when queue exceeds capacity
- ensure heavy parse/encode tasks run off main thread

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46a4533508328a67b2cabaa003e82