### PR TITLE
Add native input polyfills and validation

### DIFF
--- a/src/pages/config/index.ejs
+++ b/src/pages/config/index.ejs
@@ -25,36 +25,7 @@
     </style>
 </head>
 <body>
-<!--<section>-->
-<!--    <div class="section&#45;&#45;name">-->
-<!--        Global-->
-<!--    </div>-->
-<!--    <div class="section&#45;&#45;items">-->
-<!--        <div class="block">-->
-<!--            <div class="block&#45;&#45;label">-->
-<!--                Template-->
-<!--            </div>-->
-<!--            <div class="block&#45;&#45;input">-->
-<!--                <input />-->
-<!--            </div>-->
-<!--            <div class="block&#45;&#45;description">-->
-<!--                Select an existing template-->
-<!--            </div>-->
-<!--        </div>-->
-<!--        <div class="block">-->
-<!--            <div class="block&#45;&#45;label">-->
-<!--                Base-->
-<!--            </div>-->
-<!--            <div class="block&#45;&#45;input">-->
-<!--                <input />-->
-<!--            </div>-->
-<!--            <div class="block&#45;&#45;description">-->
-<!--                If the repository is called: &lt;username&gt;.github.io. Then the value is empty-->
-<!--                If the repository is called: portfolio, or any other name. Then the value of &lt;name of repository&gt;-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</section>-->
+<form id="settings-form">
 <section>
     <div class="section--name">
         Global
@@ -85,5 +56,46 @@
         </div>
     </div>
 </section>
+<section>
+    <div class="section--name">
+        Demo
+    </div>
+    <div class="section--items">
+        <div class="block">
+            <div class="block--label">
+                Start Date
+            </div>
+            <div class="block--input">
+                <input id="start-date" type="date"/>
+            </div>
+            <div class="block--description">
+                ISO format YYYY-MM-DD
+            </div>
+        </div>
+        <div class="block">
+            <div class="block--label">
+                Start Time
+            </div>
+            <div class="block--input">
+                <input id="start-time" type="time"/>
+            </div>
+            <div class="block--description">
+                ISO format HH:MM
+            </div>
+        </div>
+        <div class="block">
+            <div class="block--label">
+                Project Count
+            </div>
+            <div class="block--input">
+                <input id="project-count" type="number" min="0" max="99"/>
+            </div>
+            <div class="block--description">
+                Rounded and clamped between 0 and 99
+            </div>
+        </div>
+    </div>
+</section>
+</form>
 </body>
 </html>

--- a/src/pages/config/index.ts
+++ b/src/pages/config/index.ts
@@ -1,3 +1,49 @@
-(() => {
-  console.log('dev');
-})();
+import clampAndRound from './utils/validation';
+
+function inputSupports(type: string): boolean {
+  const el = document.createElement('input');
+  el.setAttribute('type', type);
+  return el.type === type;
+}
+
+function applyPolyfills() {
+  const dateInput = document.getElementById('start-date') as HTMLInputElement | null;
+  if (dateInput && !inputSupports('date')) {
+    dateInput.type = 'text';
+    dateInput.placeholder = 'YYYY-MM-DD';
+    dateInput.pattern = '\\d{4}-\\d{2}-\\d{2}';
+  }
+
+  const timeInput = document.getElementById('start-time') as HTMLInputElement | null;
+  if (timeInput && !inputSupports('time')) {
+    timeInput.type = 'text';
+    timeInput.placeholder = 'HH:MM';
+    timeInput.pattern = '\\d{2}:\\d{2}';
+  }
+}
+
+function setupForm() {
+  const form = document.getElementById('settings-form') as HTMLFormElement | null;
+  if (!form) return;
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const numberInput = document.getElementById('project-count') as HTMLInputElement | null;
+    if (numberInput) {
+      const min = numberInput.min ? Number(numberInput.min) : undefined;
+      const max = numberInput.max ? Number(numberInput.max) : undefined;
+      numberInput.value = String(clampAndRound(Number(numberInput.value), min, max));
+    }
+
+    const dateValue = (document.getElementById('start-date') as HTMLInputElement | null)?.value;
+    const timeValue = (document.getElementById('start-time') as HTMLInputElement | null)?.value;
+    const numberValue = (document.getElementById('project-count') as HTMLInputElement | null)?.value;
+
+    console.log('date', dateValue);
+    console.log('time', timeValue);
+    console.log('number', numberValue);
+  });
+}
+
+applyPolyfills();
+setupForm();

--- a/src/pages/config/utils/validation.ts
+++ b/src/pages/config/utils/validation.ts
@@ -1,0 +1,10 @@
+export default function clampAndRound(value: number, min?: number, max?: number): number {
+  let result = Math.round(value);
+  if (typeof min === 'number') {
+    result = Math.max(result, min);
+  }
+  if (typeof max === 'number') {
+    result = Math.min(result, max);
+  }
+  return result;
+}

--- a/tests/pages/config/validation.test.ts
+++ b/tests/pages/config/validation.test.ts
@@ -1,0 +1,13 @@
+import clampAndRound from '../../../src/pages/config/utils/validation';
+
+describe('clampAndRound', () => {
+  it('rounds to nearest integer', () => {
+    expect(clampAndRound(1.4)).toBe(1);
+    expect(clampAndRound(1.5)).toBe(2);
+  });
+
+  it('clamps between min and max', () => {
+    expect(clampAndRound(5, 1, 3)).toBe(3);
+    expect(clampAndRound(-1, 0, 10)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- use native date, time, and number inputs in config page
- add feature-detected fallbacks and input validation with rounding/clamping
- cover rounding/clamping utility with unit tests

## Testing
- `npx eslint src/pages/config/index.ts src/pages/config/utils/validation.ts tests/pages/config/validation.test.ts`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b46a461058832882e5650a22674a73