### PR TITLE
Add empty state analytics tracker

### DIFF
--- a/src/services/analytics/EmptyStateTracker.ts
+++ b/src/services/analytics/EmptyStateTracker.ts
@@ -1,0 +1,72 @@
+export type EmptyReason = 'none' | 'no-data' | 'error' | 'auth';
+
+interface EmptyRender {
+  reason: EmptyReason;
+  timestamp: number;
+}
+
+export interface EmptyPopulate extends EmptyRender {
+  duration: number;
+}
+
+export default class EmptyStateTracker {
+  private static renders: Map<string, EmptyRender> = new Map();
+
+  private static history: EmptyPopulate[] = [];
+
+  /**
+   * Emit an event when an empty state is rendered.
+   * @param id unique identifier of the empty screen
+   * @param reason cause of the empty state
+   */
+  static emitRender(id: string, reason: EmptyReason): void {
+    this.renders.set(id, { reason, timestamp: Date.now() });
+  }
+
+  /**
+   * Emit an event when an empty state receives content.
+   * Returns details including how long the screen stayed empty.
+   * @param id identifier used in emitRender
+   */
+  static emitPopulation(id: string): EmptyPopulate | undefined {
+    const render = this.renders.get(id);
+    if (!render) return undefined;
+
+    const duration = Date.now() - render.timestamp;
+    const populate: EmptyPopulate = { ...render, duration };
+    this.history.push(populate);
+    this.renders.delete(id);
+    return populate;
+  }
+
+  /**
+   * Get all recorded empty durations for dashboards.
+   */
+  static durations(): EmptyPopulate[] {
+    return this.history;
+  }
+
+  /**
+   * Reset tracked events (mainly for tests).
+   */
+  static reset(): void {
+    this.renders.clear();
+    this.history = [];
+  }
+
+  /**
+   * Provide a call-to-action message based on reason.
+   */
+  static ctaFor(reason: EmptyReason): string {
+    switch (reason) {
+      case 'no-data':
+        return 'Add your first item';
+      case 'error':
+        return 'Retry';
+      case 'auth':
+        return 'Sign in';
+      default:
+        return 'Learn more';
+    }
+  }
+}

--- a/tests/services/EmptyStateTracker.test.ts
+++ b/tests/services/EmptyStateTracker.test.ts
@@ -1,0 +1,23 @@
+import EmptyStateTracker from '../../src/services/analytics/EmptyStateTracker';
+
+describe('EmptyStateTracker', () => {
+  beforeEach(() => {
+    EmptyStateTracker.reset();
+  });
+
+  it('captures duration between render and population', () => {
+    const spy = jest.spyOn(Date, 'now');
+    spy.mockReturnValueOnce(0); // render time
+    EmptyStateTracker.emitRender('profile', 'no-data');
+    spy.mockReturnValueOnce(1000); // population time
+    const event = EmptyStateTracker.emitPopulation('profile');
+
+    expect(event).toEqual({ reason: 'no-data', timestamp: 0, duration: 1000 });
+    expect(EmptyStateTracker.durations()).toContainEqual(event as any);
+    spy.mockRestore();
+  });
+
+  it('provides CTA for reason', () => {
+    expect(EmptyStateTracker.ctaFor('error')).toBe('Retry');
+  });
+});


### PR DESCRIPTION
## Summary
- track when empty screens render and populate to measure duration
- expose CTA suggestions based on empty reason
- cover empty state tracking with unit tests

## Testing
- `npx eslint --ext .ts src/services/analytics tests/services`
- `npx jest tests/services/EmptyStateTracker.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b46a488cc08328adcc5b80b41e8fb6