### PR TITLE
feat: validate asset integrity

### DIFF
--- a/src/plugins/AssetHashManifestPlugin.ts
+++ b/src/plugins/AssetHashManifestPlugin.ts
@@ -1,0 +1,20 @@
+import { createHash } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Compiler } from 'webpack';
+
+export default class AssetHashManifestPlugin {
+  apply(compiler: Compiler): void {
+    compiler.hooks.afterEmit.tap('AssetHashManifestPlugin', (compilation) => {
+      const manifest: Record<string, string> = {};
+      compilation.getAssets().forEach((asset) => {
+        const source = asset.source.source();
+        const hash = createHash('sha256').update(source).digest('hex');
+        manifest[asset.name] = hash;
+      });
+      const outputPath = compiler.options.output?.path || '';
+      const manifestPath = path.join(outputPath, 'asset-manifest.json');
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    });
+  }
+}

--- a/src/templates/_common/scripts/index.ts
+++ b/src/templates/_common/scripts/index.ts
@@ -1,4 +1,47 @@
 (() => {
+  const reloadKey = 'asset-hash-reload';
+
+  async function computeHash(content: string): Promise<string> {
+    const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(content));
+    return Array.from(new Uint8Array(buffer)).map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  async function verifyAssets(): Promise<void> {
+    try {
+      const res = await fetch('/asset-manifest.json', { cache: 'no-store' });
+      const manifest = await res.json();
+      const critical = Object.keys(manifest).filter((k) => /main.*\.(js|css)$/.test(k));
+
+      await Promise.all(critical.map(async (file) => {
+        const assetRes = await fetch(`/${file}`, { cache: 'no-store' });
+        const text = await assetRes.text();
+        const hash = await computeHash(text);
+        if (hash !== manifest[file]) {
+          throw new Error(`Hash mismatch for ${file}`);
+        }
+      }));
+    } catch (err) {
+      if (!sessionStorage.getItem(reloadKey)) {
+        sessionStorage.setItem(reloadKey, '1');
+        if ('caches' in window) {
+          const keys = await caches.keys();
+          await Promise.all(keys.map((k) => caches.delete(k)));
+        }
+        window.location.reload();
+      } else {
+        document.body.innerHTML = `
+          <div style="display:flex;align-items:center;justify-content:center;height:100vh;text-align:center;padding:1rem;">
+            <div>
+              <h1>Update required</h1>
+              <p>Some files failed to load correctly. Please perform a hard refresh (Ctrl+Shift+R) to update the application.</p>
+            </div>
+          </div>`;
+      }
+    }
+  }
+
+  verifyAssets();
+
   if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,6 +13,7 @@ import { di } from './src/di';
 import Server from './src/modules/server/Server';
 import IApplication from './src/interfaces/IApplication';
 import TYPES from './src/types';
+import AssetHashManifestPlugin from './src/plugins/AssetHashManifestPlugin';
 
 function resolvePage(name: string, file: string) {
   return `./src/pages/${name}/${file}`;
@@ -166,6 +167,7 @@ export default (env: any, argv: { mode: string; }): Configuration => {
   if (isProd) {
     // @ts-ignore
     webpackConfig.plugins.push(
+      new AssetHashManifestPlugin(),
       new CleanWebpackPlugin(),
       new WebpackPwaManifest({
         background_color: '#fff',


### PR DESCRIPTION
## Summary
- create AssetHashManifestPlugin to generate asset-manifest.json with SHA-256 hashes
- verify key assets against manifest on boot and handle mismatches with refresh/error UI
- integrate manifest plugin into production webpack build

## Testing
- `npm run lint`
- `npm test`
- `npm run build` (fails: error:0308010C:digital envelope routines::unsupported)


------
https://chatgpt.com/codex/tasks/task_e_68b46a43be188328964bf73f1323d7a7