### PR TITLE
feat: add import map and dependency checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ webpack.config.ts
 .eslintrc.js
 jest.config.js
 coverage/
+scripts/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: [
     '@typescript-eslint',
+    'import',
   ],
   extends: [
     'airbnb-typescript/base',
@@ -16,5 +17,8 @@ module.exports = {
     'global-require': 0,
     'class-methods-use-this': 0,
     'import/no-extraneous-dependencies': 0,
+    'import/no-internal-modules': ['error', {
+      forbid: ['axios/**', 'inversify/**', 'reflect-metadata/**'],
+    }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "dedupe-check": "node scripts/dedupe-check.js"
   },
   "browserslist": [
     "defaults",

--- a/public/import-map.json
+++ b/public/import-map.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "axios": "https://cdn.jsdelivr.net/npm/axios@0.21.1/+esm",
+    "inversify": "https://cdn.jsdelivr.net/npm/inversify@5.1.1/+esm",
+    "reflect-metadata": "https://cdn.jsdelivr.net/npm/reflect-metadata@0.1.13/+esm"
+  }
+}

--- a/scripts/dedupe-check.js
+++ b/scripts/dedupe-check.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+let output;
+try {
+  output = execSync('npm ls --all --json', {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+} catch (err) {
+  // npm ls exits with non-zero code when there are problems, but still
+  // produces JSON output on stdout. Use it to continue processing.
+  output = err.stdout;
+}
+
+const tree = JSON.parse(output);
+const versions = new Map();
+
+function collect(deps) {
+  if (!deps) return;
+  for (const [name, info] of Object.entries(deps)) {
+    if (!versions.has(name)) versions.set(name, new Set());
+    versions.get(name).add(info.version);
+    collect(info.dependencies);
+  }
+}
+
+collect(tree.dependencies);
+
+const duplicates = Array.from(versions.entries()).filter(([, set]) => set.size > 1);
+
+if (duplicates.length > 0) {
+  console.error('Duplicate packages detected:');
+  for (const [name, set] of duplicates) {
+    console.error(`  ${name}: ${Array.from(set).join(', ')}`);
+  }
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- pin axios, inversify and reflect-metadata via browser import map
- prevent deep imports from shared libs with ESLint
- add dependency dedupe check for CI

## Testing
- `npm test`
- `npm run lint`
- `npm run dedupe-check` *(fails: Duplicate packages detected)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a5709c08328bf67782d6a3ebebd