### PR TITLE
Add email template previews and validation utility

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!email-samples/
+!email-samples/**

--- a/data/email-samples/reset-password.json
+++ b/data/email-samples/reset-password.json
@@ -1,0 +1,4 @@
+{
+  "name": "Jane Doe",
+  "resetUrl": "https://example.com/reset"
+}

--- a/data/email-samples/welcome.json
+++ b/data/email-samples/welcome.json
@@ -1,0 +1,3 @@
+{
+  "name": "Jane Doe"
+}

--- a/src/emails/previews/password-reset.tsx
+++ b/src/emails/previews/password-reset.tsx
@@ -1,0 +1,9 @@
+import { PasswordResetEmail } from '../templates/PasswordResetEmail';
+const data = require('../../../data/email-samples/reset-password.json');
+
+const html = PasswordResetEmail(data);
+if (!html.includes('prefers-color-scheme: dark')) {
+  console.warn('Dark mode styles missing.');
+}
+
+export default html;

--- a/src/emails/previews/welcome.tsx
+++ b/src/emails/previews/welcome.tsx
@@ -1,0 +1,9 @@
+import { WelcomeEmail } from '../templates/WelcomeEmail';
+const data = require('../../../data/email-samples/welcome.json');
+
+const html = WelcomeEmail(data);
+if (!html.includes('prefers-color-scheme: dark')) {
+  console.warn('Dark mode styles missing.');
+}
+
+export default html;

--- a/src/emails/templates/PasswordResetEmail.ts
+++ b/src/emails/templates/PasswordResetEmail.ts
@@ -1,0 +1,22 @@
+export interface PasswordResetEmailProps {
+  name: string;
+  resetUrl: string;
+}
+
+const styles = `body { font-family: Arial, sans-serif; background: #ffffff; color: #000000; }
+@media (prefers-color-scheme: dark) { body { background: #000000; color: #ffffff; } }`;
+
+export function PasswordResetEmail({ name, resetUrl }: PasswordResetEmailProps): string {
+  return `<html>
+  <head>
+    <meta name="color-scheme" content="light dark" />
+    <style>${styles}</style>
+  </head>
+  <body>
+    <h1>Password reset</h1>
+    <p>Hello ${name},</p>
+    <p>Click <a href="${resetUrl}">here</a> to reset your password.</p>
+    <img src="https://via.placeholder.com/150" alt="Company logo" />
+  </body>
+</html>`;
+}

--- a/src/emails/templates/WelcomeEmail.ts
+++ b/src/emails/templates/WelcomeEmail.ts
@@ -1,0 +1,20 @@
+export interface WelcomeEmailProps {
+  name: string;
+}
+
+const styles = `body { font-family: Arial, sans-serif; background: #ffffff; color: #000000; }
+@media (prefers-color-scheme: dark) { body { background: #000000; color: #ffffff; } }`;
+
+export function WelcomeEmail({ name }: WelcomeEmailProps): string {
+  return `<html>
+  <head>
+    <meta name="color-scheme" content="light dark" />
+    <style>${styles}</style>
+  </head>
+  <body>
+    <h1>Welcome, ${name}!</h1>
+    <p>We're excited to have you on board.</p>
+    <img src="https://via.placeholder.com/150" alt="Company logo" />
+  </body>
+</html>`;
+}

--- a/src/emails/validate.ts
+++ b/src/emails/validate.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+import { WelcomeEmail } from './templates/WelcomeEmail';
+import { PasswordResetEmail } from './templates/PasswordResetEmail';
+
+const welcomeData = require('../../data/email-samples/welcome.json');
+const resetData = require('../../data/email-samples/reset-password.json');
+
+type Template = { name: string; html: string };
+
+function inlineCss(html: string): string {
+  const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/i);
+  if (!styleMatch) return html;
+  const css = styleMatch[1];
+  let result = html.replace(styleMatch[0], '');
+  const bodyMatch = css.match(/body\s*{([^}]*)}/i);
+  if (bodyMatch) {
+    result = result.replace('<body', `<body style="${bodyMatch[1].trim()}"`);
+  }
+  return result;
+}
+
+function checkAlt(html: string): void {
+  const imgs = html.match(/<img [^>]*>/gi) || [];
+  imgs.forEach((tag) => {
+    if (!/alt=/.test(tag)) {
+      throw new Error('Image missing alt text');
+    }
+  });
+}
+
+function toText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const templates: Template[] = [
+  { name: 'welcome', html: WelcomeEmail(welcomeData) },
+  { name: 'reset-password', html: PasswordResetEmail(resetData) },
+];
+
+templates.forEach((t) => {
+  const inlined = inlineCss(t.html);
+  checkAlt(inlined);
+  const text = toText(inlined);
+  const outDir = path.join(__dirname, 'output');
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir);
+  }
+  fs.writeFileSync(path.join(outDir, `${t.name}.html`), inlined);
+  fs.writeFileSync(path.join(outDir, `${t.name}.txt`), text);
+});


### PR DESCRIPTION
## Summary
- add simple Welcome and Password Reset email templates
- expose template preview pages with basic dark mode check
- provide validation script to inline CSS, verify alt text, and write plain-text versions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a58aa0c83288271a03534d922d3