### PR TITLE
feat: add telemetry hooks and navigation metrics

### DIFF
--- a/src/hooks/usePageTelemetry.ts
+++ b/src/hooks/usePageTelemetry.ts
@@ -1,0 +1,49 @@
+export interface PageTelemetry {
+  title: string;
+  section: string;
+  breadcrumb: string[];
+}
+
+export type TelemetryEmitter = (data: PageTelemetry) => void;
+
+/**
+ * Register listeners for route changes and emit page telemetry.
+ *
+ * The provided `emitter` will be called with current page `title`, first
+ * `section` of the path and an array `breadcrumb` on each navigation event.
+ *
+ * @param emitter - function handling telemetry payload
+ * @returns cleanup function removing listeners
+ */
+export default function usePageTelemetry(emitter: TelemetryEmitter): () => void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+
+  const buildPayload = (): PageTelemetry => {
+    const { title } = document;
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const section = segments[0] || '';
+
+    return {
+      title,
+      section,
+      breadcrumb: segments,
+    };
+  };
+
+  const handler = (): void => {
+    emitter(buildPayload());
+  };
+
+  window.addEventListener('popstate', handler);
+  window.addEventListener('hashchange', handler);
+
+  // Emit once on registration
+  handler();
+
+  return () => {
+    window.removeEventListener('popstate', handler);
+    window.removeEventListener('hashchange', handler);
+  };
+}

--- a/src/metrics/navigationReport.ts
+++ b/src/metrics/navigationReport.ts
@@ -1,0 +1,39 @@
+export interface NavigationReport {
+  /**
+   * Aggregated counts of full session paths.
+   * The key is a path joined by '>' characters.
+   */
+  paths: Record<string, number>;
+  /**
+   * Number of times users dropped off on a particular page.
+   * Key is the last page of a session.
+   */
+  dropOffs: Record<string, number>;
+}
+
+/**
+ * Build a navigation report from a list of session paths.
+ *
+ * @param sessions - array of session path arrays
+ * @returns aggregated navigation report
+ */
+export default function navigationReport(sessions: string[][]): NavigationReport {
+  const report: NavigationReport = {
+    paths: {},
+    dropOffs: {},
+  };
+
+  sessions.forEach((session) => {
+    if (session.length === 0) {
+      return;
+    }
+
+    const pathKey = session.join('>');
+    report.paths[pathKey] = (report.paths[pathKey] || 0) + 1;
+
+    const last = session[session.length - 1];
+    report.dropOffs[last] = (report.dropOffs[last] || 0) + 1;
+  });
+
+  return report;
+}

--- a/src/utils/perfMarks.ts
+++ b/src/utils/perfMarks.ts
@@ -1,0 +1,36 @@
+export const markFirstPaint = (): void => {
+  if (typeof window === 'undefined' || typeof performance === 'undefined') {
+    return;
+  }
+
+  const startMark = 'first-paint-start';
+  const endMark = 'first-paint-end';
+  const measureName = 'first-paint';
+
+  if (typeof performance.mark !== 'function' || typeof performance.measure !== 'function') {
+    return;
+  }
+
+  performance.mark(startMark);
+
+  const afterPaint = (): void => {
+    performance.mark(endMark);
+    try {
+      performance.measure(measureName, startMark, endMark);
+    } catch (e) {
+      // ignore measure errors
+    }
+  };
+
+  if (document.readyState === 'complete') {
+    requestAnimationFrame(afterPaint);
+  } else {
+    window.addEventListener('load', () => {
+      requestAnimationFrame(afterPaint);
+    });
+  }
+};
+
+export default {
+  markFirstPaint,
+};

--- a/tests/metrics/navigationReport.test.ts
+++ b/tests/metrics/navigationReport.test.ts
@@ -1,0 +1,21 @@
+import navigationReport from '../../src/metrics/navigationReport';
+
+describe('navigationReport', () => {
+  it('aggregates session paths and drop-offs', () => {
+    const sessions = [
+      ['home', 'about', 'contact'],
+      ['home', 'about'],
+      ['home', 'blog'],
+    ];
+
+    const report = navigationReport(sessions);
+
+    expect(report.paths['home>about>contact']).toBe(1);
+    expect(report.paths['home>about']).toBe(1);
+    expect(report.paths['home>blog']).toBe(1);
+
+    expect(report.dropOffs.about).toBe(1);
+    expect(report.dropOffs.contact).toBe(1);
+    expect(report.dropOffs.blog).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `usePageTelemetry` hook for emitting page telemetry on route changes
- track first paint performance marks
- aggregate session paths and drop-offs in navigation report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a5b6c308328b7b3a966affe67fe