### PR TITLE
feat: add error dictionary and localization

### DIFF
--- a/src/errors/dictionary.ts
+++ b/src/errors/dictionary.ts
@@ -1,0 +1,25 @@
+export interface ErrorMessage {
+  short: string;
+  long: string;
+}
+
+export const ERROR_DICTIONARY: Record<string, ErrorMessage> = {
+  UNKNOWN: {
+    short: 'Unknown error',
+    long: 'An unexpected error occurred.',
+  },
+  NOT_FOUND: {
+    short: 'Not found',
+    long: 'Requested resource could not be found.',
+  },
+  PERMISSION_DENIED: {
+    short: 'Permission denied',
+    long: 'You are not allowed to perform this action.',
+  },
+  TIMEOUT: {
+    short: 'Timeout',
+    long: 'The request to {{resource}} timed out.',
+  },
+};
+
+export type ErrorKey = keyof typeof ERROR_DICTIONARY;

--- a/src/errors/map.ts
+++ b/src/errors/map.ts
@@ -1,0 +1,13 @@
+import { ERROR_DICTIONARY, ErrorKey, ErrorMessage } from './dictionary';
+
+export const SERVER_ERROR_MAP: Record<string, ErrorKey> = {
+  ENOENT: 'NOT_FOUND',
+  EACCES: 'PERMISSION_DENIED',
+  ETIMEDOUT: 'TIMEOUT',
+  ECONNABORTED: 'TIMEOUT',
+};
+
+export function mapServerErrorCode(code: string): ErrorMessage {
+  const key = SERVER_ERROR_MAP[code] || 'UNKNOWN';
+  return ERROR_DICTIONARY[key];
+}

--- a/src/i18n/errors/en.json
+++ b/src/i18n/errors/en.json
@@ -1,0 +1,6 @@
+{
+  "UNKNOWN": "An unexpected error occurred.",
+  "NOT_FOUND": "Requested resource could not be found.",
+  "PERMISSION_DENIED": "You are not allowed to perform this action.",
+  "TIMEOUT": "The request to {{resource}} timed out."
+}

--- a/src/i18n/errors/validatePlaceholders.ts
+++ b/src/i18n/errors/validatePlaceholders.ts
@@ -1,0 +1,36 @@
+import { ERROR_DICTIONARY } from '../../errors/dictionary';
+
+const PLACEHOLDER_REGEXP = /{{(.*?)}}/g;
+
+function extract(str: string): Set<string> {
+  const result = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = PLACEHOLDER_REGEXP.exec(str)) !== null) {
+    result.add(match[1]);
+  }
+  return result;
+}
+
+export function validatePlaceholders(
+  dictionary: typeof ERROR_DICTIONARY,
+  locale: Record<string, string>,
+): void {
+  Object.keys(dictionary).forEach((key) => {
+    const dictPlaceholders = extract(dictionary[key].long);
+    const localeMessage = locale[key];
+    if (!localeMessage) {
+      throw new Error(`Missing translation for key ${key}`);
+    }
+    const localePlaceholders = extract(localeMessage);
+    dictPlaceholders.forEach((ph) => {
+      if (!localePlaceholders.has(ph)) {
+        throw new Error(`Missing placeholder ${ph} in translation for key ${key}`);
+      }
+    });
+    localePlaceholders.forEach((ph) => {
+      if (!dictPlaceholders.has(ph)) {
+        throw new Error(`Unknown placeholder ${ph} in translation for key ${key}`);
+      }
+    });
+  });
+}

--- a/tests/errors/map.test.ts
+++ b/tests/errors/map.test.ts
@@ -1,0 +1,13 @@
+import { mapServerErrorCode } from '../../src/errors/map';
+
+describe('server error map', () => {
+  it('should map known code', () => {
+    const error = mapServerErrorCode('ENOENT');
+    expect(error.short).toBe('Not found');
+  });
+
+  it('should default to unknown', () => {
+    const error = mapServerErrorCode('SOME_CODE');
+    expect(error.short).toBe('Unknown error');
+  });
+});

--- a/tests/errors/placeholder.test.ts
+++ b/tests/errors/placeholder.test.ts
@@ -1,0 +1,10 @@
+import { ERROR_DICTIONARY } from '../../src/errors/dictionary';
+import { validatePlaceholders } from '../../src/i18n/errors/validatePlaceholders';
+
+const en = require('../../src/i18n/errors/en.json');
+
+describe('error locale placeholders', () => {
+  it('should match dictionary placeholders', () => {
+    expect(() => validatePlaceholders(ERROR_DICTIONARY, en)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- centralize error messages with short and long forms
- map server error codes to friendly messages
- add error locale with placeholder validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a5d5184832883c4fdb388eb68f2