### PR TITLE
feat: add live region announcements

### DIFF
--- a/src/components/LiveRegion.tsx
+++ b/src/components/LiveRegion.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const visuallyHidden: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  margin: '-1px',
+  padding: '0',
+  border: '0',
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+};
+
+const LiveRegion: React.FC = () => (
+  <>
+    <div
+      id="live-region-polite"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      style={visuallyHidden}
+    />
+    <div
+      id="live-region-assertive"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      style={visuallyHidden}
+    />
+  </>
+);
+
+export default LiveRegion;

--- a/src/utils/announce.ts
+++ b/src/utils/announce.ts
@@ -1,0 +1,31 @@
+export type Politeness = 'polite' | 'assertive';
+
+const lastMessages: Record<Politeness, string> = {
+  polite: '',
+  assertive: '',
+};
+
+function setMessage(message: string, politeness: Politeness): void {
+  const region = document.getElementById(`live-region-${politeness}`);
+  if (!region) {
+    return;
+  }
+
+  const text = lastMessages[politeness] === message ? `${message}\u00A0` : message;
+  lastMessages[politeness] = message;
+  region.textContent = text;
+}
+
+export function announce(message: string, politeness: Politeness = 'polite'): void {
+  setMessage(message, politeness);
+}
+
+export function announcePolite(message: string): void {
+  setMessage(message, 'polite');
+}
+
+export function announceAssertive(message: string): void {
+  setMessage(message, 'assertive');
+}
+
+export default announce;

--- a/tests/a11y/announcements.test.ts
+++ b/tests/a11y/announcements.test.ts
@@ -1,0 +1,34 @@
+import { JSDOM } from 'jsdom';
+import { announce } from '../../src/utils/announce';
+
+describe('announcement utilities', () => {
+  let dom: any;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body>'
+      + '<div id="live-region-polite"></div>'
+      + '<div id="live-region-assertive"></div>'
+      + '</body></html>');
+    // @ts-ignore
+    global.document = dom.window.document;
+  });
+
+  it('announces politely', () => {
+    announce('Hello');
+    const region = dom.window.document.getElementById('live-region-polite');
+    expect(region?.textContent).toBe('Hello');
+  });
+
+  it('announces assertively', () => {
+    announce('Warning', 'assertive');
+    const region = dom.window.document.getElementById('live-region-assertive');
+    expect(region?.textContent).toBe('Warning');
+  });
+
+  it('avoids repeated messages', () => {
+    announce('Repeat');
+    announce('Repeat');
+    const region = dom.window.document.getElementById('live-region-polite');
+    expect(region?.textContent).toBe('Repeat\u00A0');
+  });
+});

--- a/tests/types.d.ts
+++ b/tests/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'jsdom';


### PR DESCRIPTION
## Summary
- add LiveRegion component for polite and assertive ARIA messages
- provide announce utilities that prevent duplicate announcements
- test announcement behavior for polite, assertive, and repeated messages

## Testing
- `yarn exec eslint src/components/LiveRegion.tsx src/utils/announce.ts tests/a11y/announcements.test.ts -f json`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a5df6388328bd376275f2228ff4