### PR TITLE
feat: add idle detection and network pause

### DIFF
--- a/src/components/IdleLock.tsx
+++ b/src/components/IdleLock.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface IProps {
+  onResume: () => void;
+  message?: string;
+}
+
+export default function IdleLock({ onResume, message = 'Session paused due to inactivity. Click or press any key to resume.' }: IProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onResume}
+      onKeyDown={onResume}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.6)',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999,
+      }}
+    >
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/src/hooks/useIdleDetector.ts
+++ b/src/hooks/useIdleDetector.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useIdleDetector(onIdle: () => void, timeout = 30000): boolean {
+  const [idle, setIdle] = useState(false);
+  const timer = useRef<NodeJS.Timeout | undefined>();
+
+  const resetTimer = () => {
+    if (timer.current) clearTimeout(timer.current);
+    setIdle(false);
+    timer.current = setTimeout(() => {
+      setIdle(true);
+      onIdle();
+    }, timeout);
+  };
+
+  useEffect(() => {
+    const events = ['mousemove', 'mousedown', 'keypress', 'scroll', 'touchstart'];
+    events.forEach((event) => window.addEventListener(event, resetTimer));
+    resetTimer();
+
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+      events.forEach((event) => window.removeEventListener(event, resetTimer));
+    };
+  }, [timeout, onIdle]);
+
+  return idle;
+}

--- a/src/utils/networkPause.ts
+++ b/src/utils/networkPause.ts
@@ -1,0 +1,39 @@
+export default function networkPause() {
+  const originalFetch = window.fetch.bind(window);
+
+  type QueuedRequest = {
+    args: Parameters<typeof fetch>;
+    resolve: (value: Response) => void;
+    reject: (reason?: unknown) => void;
+  };
+
+  const queue: QueuedRequest[] = [];
+  let paused = document.hidden;
+
+  const processQueue = () => {
+    while (queue.length > 0) {
+      const { args, resolve, reject } = queue.shift()!;
+      originalFetch(...args).then(resolve).catch(reject);
+    }
+  };
+
+  const wrappedFetch = (
+    ...args: Parameters<typeof fetch>
+  ): Promise<Response> => {
+    if (paused) {
+      return new Promise<Response>((resolve, reject) => {
+        queue.push({ args, resolve, reject });
+      });
+    }
+    return originalFetch(...args);
+  };
+
+  document.addEventListener('visibilitychange', () => {
+    paused = document.hidden;
+    if (!paused) {
+      processQueue();
+    }
+  });
+
+  window.fetch = wrappedFetch;
+}


### PR DESCRIPTION
## Summary
- add `useIdleDetector` hook to trigger autosave after inactivity
- create `IdleLock` overlay component explaining how to resume
- pause network requests when tab hidden with `networkPause`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a5f9130832886dba22246af5a5c