### PR TITLE
feat: add route capability auditing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run eslint
         run: yarn lint
 
+      - name: Check route capabilities
+        run: yarn check:route-capabilities
+
       - name: Run tests
         run: yarn test --coverage
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!route-capabilities.json

--- a/data/route-capabilities.json
+++ b/data/route-capabilities.json
@@ -1,0 +1,10 @@
+{
+  "/": {
+    "owner": "core",
+    "reviewer": "core"
+  },
+  "/admin/route-audit": {
+    "owner": "core",
+    "reviewer": "core"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "check:route-capabilities": "ts-node ./scripts/checkRouteCapabilities.ts"
   },
   "browserslist": [
     "defaults",

--- a/scripts/checkRouteCapabilities.ts
+++ b/scripts/checkRouteCapabilities.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { auditRoutes, getPageRoutes, loadRouteCapabilities } from '../src/utils/routeAudit';
+
+const capabilitiesPath = path.resolve(__dirname, '../data/route-capabilities.json');
+const pagesDir = path.resolve(__dirname, '../src/pages');
+
+const capabilities = loadRouteCapabilities(capabilitiesPath);
+const routes = getPageRoutes(pagesDir);
+const { missing } = auditRoutes(capabilities, routes);
+
+if (missing.length > 0) {
+  // eslint-disable-next-line no-console
+  console.error('Missing route capabilities for:\n', missing.join('\n'));
+  process.exit(1);
+}

--- a/src/pages/admin/route-audit.tsx
+++ b/src/pages/admin/route-audit.tsx
@@ -1,0 +1,19 @@
+import path from 'path';
+import { auditRoutes, getPageRoutes, loadRouteCapabilities } from '../../utils/routeAudit';
+
+const capabilities = loadRouteCapabilities(path.resolve(__dirname, '../../../data/route-capabilities.json'));
+const routes = getPageRoutes(path.resolve(__dirname, '..'));
+
+const results = auditRoutes(capabilities, routes);
+
+function render(): void {
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(results, null, 2);
+  document.body.appendChild(pre);
+}
+
+if (typeof document !== 'undefined') {
+  render();
+}
+
+export default results;

--- a/src/utils/routeAudit.ts
+++ b/src/utils/routeAudit.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface RouteCapability {
+  owner: string;
+  reviewer: string;
+}
+
+export type RouteCapabilities = Record<string, RouteCapability>;
+
+export function getPageRoutes(pagesDir: string): string[] {
+  const routes: string[] = [];
+
+  function walk(dir: string, base: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    entries.forEach((entry) => {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name === 'config') {
+          return;
+        }
+        const nextBase = `${base}/${entry.name}`;
+        walk(fullPath, nextBase);
+      } else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
+        const name = entry.name.replace(/\.tsx?$/, '');
+        const route = name === 'index' ? base || '/' : `${base}/${name}`;
+        routes.push(route.replace(/\\/g, '/').replace(/\/+/g, '/'));
+      }
+    });
+  }
+
+  walk(pagesDir, '');
+  return routes;
+}
+
+export function auditRoutes(capabilities: RouteCapabilities, routes: string[]): {
+  missing: string[];
+  unknown: string[];
+  duplicates: string[];
+} {
+  const missing = routes.filter((r) => capabilities[r] === undefined);
+  const unknown = Object.keys(capabilities).filter((r) => !routes.includes(r));
+  const duplicates: string[] = [];
+  const seen = new Set<string>();
+
+  routes.forEach((r) => {
+    if (seen.has(r)) {
+      duplicates.push(r);
+    } else {
+      seen.add(r);
+    }
+  });
+
+  return { missing, unknown, duplicates };
+}
+
+export function loadRouteCapabilities(filePath: string): RouteCapabilities {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as RouteCapabilities;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   "include": [
     "src",
     "tests",
+    "scripts",
   ],
 }


### PR DESCRIPTION
## Summary
- define route capability table with owner and reviewer info
- add admin route audit page and shared utilities
- enforce route capability coverage in CI

## Testing
- `yarn check:route-capabilities`
- `yarn lint`
- `yarn test`
- `yarn build` *(fails: error:0308010C:digital envelope routines::unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a627cec8328ba056fa51072d948