### PR TITLE
feat: add diagnostics capture and opt-out

### DIFF
--- a/src/pages/settings/privacy.tsx
+++ b/src/pages/settings/privacy.tsx
@@ -1,0 +1,17 @@
+import DiagnosticsStore from '../../services/diagnosticsStore';
+
+function init(): void {
+  DiagnosticsStore.collect();
+
+  const checkbox = document.querySelector<HTMLInputElement>('#diagnostics-opt-out');
+  if (!checkbox) {
+    return;
+  }
+
+  checkbox.checked = DiagnosticsStore.isOptOut();
+  checkbox.addEventListener('change', () => {
+    DiagnosticsStore.setOptOut(checkbox.checked);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/src/services/diagnosticsStore.ts
+++ b/src/services/diagnosticsStore.ts
@@ -1,0 +1,69 @@
+import getDeviceInfo, { IDeviceInfo } from '../utils/deviceInfo';
+
+const STORAGE_KEY = 'diagnostics';
+const OPT_OUT_KEY = 'diagnosticsOptOut';
+
+function hasSessionStorage(): boolean {
+  try {
+    return typeof sessionStorage !== 'undefined';
+  } catch (e) {
+    return false;
+  }
+}
+
+function hasLocalStorage(): boolean {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch (e) {
+    return false;
+  }
+}
+
+export default class DiagnosticsStore {
+  public static load(): IDeviceInfo | null {
+    if (!hasSessionStorage()) {
+      return null;
+    }
+
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  }
+
+  public static save(info: IDeviceInfo): void {
+    if (!hasSessionStorage()) {
+      return;
+    }
+
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(info));
+  }
+
+  public static isOptOut(): boolean {
+    if (!hasLocalStorage()) {
+      return false;
+    }
+
+    return localStorage.getItem(OPT_OUT_KEY) === 'true';
+  }
+
+  public static setOptOut(value: boolean): void {
+    if (!hasLocalStorage()) {
+      return;
+    }
+
+    if (value) {
+      localStorage.setItem(OPT_OUT_KEY, 'true');
+    } else {
+      localStorage.removeItem(OPT_OUT_KEY);
+    }
+  }
+
+  public static collect(): void {
+    if (DiagnosticsStore.isOptOut()) {
+      return;
+    }
+
+    if (!DiagnosticsStore.load()) {
+      DiagnosticsStore.save(getDeviceInfo());
+    }
+  }
+}

--- a/src/utils/deviceInfo.ts
+++ b/src/utils/deviceInfo.ts
@@ -1,0 +1,27 @@
+export interface IDeviceInfo {
+  userAgent: string | null;
+  memory: number | null;
+  hardwareConcurrency: number | null;
+  reducedMotion: boolean;
+}
+
+export default function getDeviceInfo(): IDeviceInfo {
+  const nav: any = typeof navigator !== 'undefined' ? navigator : {};
+  const win: any = typeof window !== 'undefined' ? window : {};
+
+  const userAgent: string | null = nav.userAgent || null;
+  const memory: number | null = typeof nav.deviceMemory === 'number' ? nav.deviceMemory : null;
+  const hardwareConcurrency: number | null =
+    typeof nav.hardwareConcurrency === 'number' ? nav.hardwareConcurrency : null;
+  const reducedMotion: boolean =
+    typeof win.matchMedia === 'function'
+      ? win.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+
+  return {
+    userAgent,
+    memory,
+    hardwareConcurrency,
+    reducedMotion,
+  };
+}

--- a/tests/services/diagnosticsStore.test.ts
+++ b/tests/services/diagnosticsStore.test.ts
@@ -1,0 +1,62 @@
+import DiagnosticsStore from '../../src/services/diagnosticsStore';
+import getDeviceInfo from '../../src/utils/deviceInfo';
+
+jest.mock('../../src/utils/deviceInfo');
+
+describe('DiagnosticsStore', () => {
+  const deviceInfoMock = getDeviceInfo as jest.MockedFunction<typeof getDeviceInfo>;
+
+  const storageMock = () => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => { store[key] = value; },
+      removeItem: (key: string) => { delete store[key]; },
+      clear: () => { store = {}; },
+    };
+  };
+
+  beforeEach(() => {
+    deviceInfoMock.mockReturnValue({
+      userAgent: 'agent',
+      memory: 2,
+      hardwareConcurrency: 4,
+      reducedMotion: false,
+    });
+
+    (global as any).sessionStorage = storageMock();
+    (global as any).localStorage = storageMock();
+  });
+
+  afterEach(() => {
+    deviceInfoMock.mockReset();
+    delete (global as any).sessionStorage;
+    delete (global as any).localStorage;
+  });
+
+  it('collects diagnostics when not opted out', () => {
+    DiagnosticsStore.collect();
+
+    expect(sessionStorage.getItem('diagnostics')).toBe(JSON.stringify({
+      userAgent: 'agent',
+      memory: 2,
+      hardwareConcurrency: 4,
+      reducedMotion: false,
+    }));
+  });
+
+  it('does not collect when opted out', () => {
+    localStorage.setItem('diagnosticsOptOut', 'true');
+    DiagnosticsStore.collect();
+
+    expect(sessionStorage.getItem('diagnostics')).toBeNull();
+  });
+
+  it('setOptOut persists choice', () => {
+    DiagnosticsStore.setOptOut(true);
+    expect(localStorage.getItem('diagnosticsOptOut')).toBe('true');
+
+    DiagnosticsStore.setOptOut(false);
+    expect(localStorage.getItem('diagnosticsOptOut')).toBeNull();
+  });
+});

--- a/tests/utils/deviceInfo.test.ts
+++ b/tests/utils/deviceInfo.test.ts
@@ -1,0 +1,41 @@
+import getDeviceInfo from '../../src/utils/deviceInfo';
+
+describe('deviceInfo', () => {
+  const originalNavigator = global.navigator;
+  const originalWindow = (global as any).window;
+
+  afterEach(() => {
+    (global as any).navigator = originalNavigator;
+    (global as any).window = originalWindow;
+  });
+
+  it('returns info from navigator and window', () => {
+    (global as any).navigator = {
+      userAgent: 'agent',
+      hardwareConcurrency: 4,
+      deviceMemory: 2,
+    } as any;
+    (global as any).window = {
+      matchMedia: jest.fn().mockReturnValue({ matches: true }),
+    } as any;
+
+    expect(getDeviceInfo()).toStrictEqual({
+      userAgent: 'agent',
+      memory: 2,
+      hardwareConcurrency: 4,
+      reducedMotion: true,
+    });
+  });
+
+  it('handles absence of browser globals', () => {
+    delete (global as any).navigator;
+    delete (global as any).window;
+
+    expect(getDeviceInfo()).toStrictEqual({
+      userAgent: null,
+      memory: null,
+      hardwareConcurrency: null,
+      reducedMotion: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- capture device details (user agent, memory, cores, reduced motion) in deviceInfo util
- persist session diagnostics with opt-out controls
- add privacy settings toggle for diagnostics collection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a62de2c83289ff3f964cd7bccd7