### PR TITLE
Add version headers and client version check

### DIFF
--- a/src/features/versionFlags.ts
+++ b/src/features/versionFlags.ts
@@ -1,0 +1,18 @@
+export interface VersionFlags {
+  legacySchemaHeader: boolean;
+}
+
+export const versionFlags: VersionFlags = {
+  legacySchemaHeader: true,
+};
+
+export function parseVersion(headers: Record<string, string>): { api?: string; schema?: string } {
+  const api = headers['x-api-version'];
+  let schema = headers['x-schema-version'];
+
+  if (!schema && versionFlags.legacySchemaHeader) {
+    schema = headers['x-db-schema-version'] || headers['x-schema'];
+  }
+
+  return { api, schema };
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,10 +1,12 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import versionMiddleware from '../../server/middleware/version';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
+    app.use(versionMiddleware);
     // app.get('/api/sh/build', async (req: any, resp: any) => {
     //   const response = await build();
     //   resp.json(response);

--- a/src/server/middleware/version.ts
+++ b/src/server/middleware/version.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express';
+
+const API_VERSION = process.env.API_VERSION || '1.0';
+const SCHEMA_VERSION = process.env.SCHEMA_VERSION || '1.0';
+
+export default function versionMiddleware(req: Request, res: Response, next: NextFunction): void {
+  res.setHeader('X-API-Version', API_VERSION);
+  res.setHeader('X-Schema-Version', SCHEMA_VERSION);
+  next();
+}

--- a/src/utils/versionCheck.ts
+++ b/src/utils/versionCheck.ts
@@ -1,0 +1,27 @@
+import { parseVersion } from '../features/versionFlags';
+
+export interface VersionInfo {
+  api: string;
+  schema: string;
+}
+
+export default class VersionCheck {
+  static isOutdated(server: VersionInfo, client: VersionInfo): boolean {
+    return server.api !== client.api || server.schema !== client.schema;
+  }
+
+  static ensure(server: VersionInfo, client: VersionInfo): void {
+    if (VersionCheck.isOutdated(server, client)) {
+      if (typeof window !== 'undefined' && window.confirm('A new version is available. Reload?')) {
+        window.location.reload();
+      }
+    }
+  }
+
+  static ensureFromHeaders(headers: Record<string, string>, client: VersionInfo): void {
+    const server = parseVersion(headers);
+    if (server.api && server.schema) {
+      VersionCheck.ensure(server as VersionInfo, client);
+    }
+  }
+}

--- a/tests/utils/versionCheck.test.ts
+++ b/tests/utils/versionCheck.test.ts
@@ -1,0 +1,15 @@
+import VersionCheck, { VersionInfo } from '../../src/utils/versionCheck';
+
+describe('VersionCheck', () => {
+  it('identifies up-to-date versions', () => {
+    const server: VersionInfo = { api: '1', schema: '1' };
+    const client: VersionInfo = { api: '1', schema: '1' };
+    expect(VersionCheck.isOutdated(server, client)).toBe(false);
+  });
+
+  it('identifies outdated versions', () => {
+    const server: VersionInfo = { api: '2', schema: '1' };
+    const client: VersionInfo = { api: '1', schema: '1' };
+    expect(VersionCheck.isOutdated(server, client)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add middleware to send API and schema versions in headers
- provide client utility to check versions and prompt reload
- support legacy schema headers via feature flag parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a63c3908328bed01b9582b8ecae