### PR TITLE
Add incident runbooks and simulation preview

### DIFF
--- a/docs/incidents/api-outage-runbook.md
+++ b/docs/incidents/api-outage-runbook.md
@@ -1,0 +1,15 @@
+# API Outage Runbook
+
+**Owner:** `api-team@example.com`
+
+## Purpose
+Guide to restore API availability when monitoring detects downtime.
+
+## Checklist
+- [ ] Confirm alert from monitoring system
+- [ ] Notify API team and incident channel
+- [ ] Review recent deployments for regressions
+- [ ] Check API logs and metrics for anomalies
+- [ ] Roll back or patch as needed
+- [ ] Update status page and communicate resolution
+- [ ] Initiate postmortem using template

--- a/docs/incidents/db-outage-runbook.md
+++ b/docs/incidents/db-outage-runbook.md
@@ -1,0 +1,15 @@
+# Database Outage Runbook
+
+**Owner:** `db-team@example.com`
+
+## Purpose
+Procedures for diagnosing and recovering from database outages.
+
+## Checklist
+- [ ] Verify outage through monitoring alerts
+- [ ] Enable read-only mode if possible
+- [ ] Examine primary and replica health
+- [ ] Restore from backup or fail over if necessary
+- [ ] Validate application functionality
+- [ ] Communicate status to stakeholders
+- [ ] Record incident timeline for postmortem

--- a/docs/incidents/postmortem-template.md
+++ b/docs/incidents/postmortem-template.md
@@ -1,0 +1,22 @@
+# Postmortem Template
+
+## Summary
+<!-- Provide a brief summary of the incident. -->
+
+## Impact
+<!-- Describe customer impact and affected systems. -->
+
+## Root Cause
+<!-- Detail the underlying cause of the incident. -->
+
+## Timeline
+| Time (UTC) | Event |
+|-----------|-------|
+| HH:MM | Description |
+
+## Action Items
+- [ ] Add follow-up tasks here
+- [ ] Assign owners and due dates
+
+## Lessons Learned
+<!-- What went well? What could be improved? -->

--- a/src/pages/admin/incidentSim.tsx
+++ b/src/pages/admin/incidentSim.tsx
@@ -1,0 +1,21 @@
+const failureBannerId = 'simulated-failure-banner';
+
+function renderBanner(): void {
+  if (document.getElementById(failureBannerId)) return;
+
+  const banner = document.createElement('div');
+  banner.id = failureBannerId;
+  banner.textContent = 'Simulated Failure';
+  banner.className = 'banner banner--failure';
+  document.body.appendChild(banner);
+}
+
+function setupDryRun(): void {
+  const button = document.createElement('button');
+  button.textContent = 'Dry Run';
+  button.addEventListener('click', renderBanner);
+  document.body.appendChild(button);
+}
+
+document.addEventListener('DOMContentLoaded', setupDryRun);
+export {};


### PR DESCRIPTION
## Summary
- add API and DB outage runbook docs with owners and checklists
- add dry-run button in incident simulation preview to show failure banners
- provide post-incident postmortem template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a6502c483289c657e395021bc02