### PR TITLE
Add UI stress test script and memory leak harness

### DIFF
--- a/reports/ui-stress.json
+++ b/reports/ui-stress.json
@@ -1,0 +1,5 @@
+{
+  "frameRate": 0,
+  "longTasks": [],
+  "memory": { "leak": 0, "duration": 0 }
+}

--- a/scripts/harness.js
+++ b/scripts/harness.js
@@ -1,0 +1,20 @@
+const { performance } = require('perf_hooks');
+
+async function withMemoryLeakCheck(fn) {
+  performance.mark('mem-start');
+  const start = process.memoryUsage().heapUsed;
+  const result = await fn();
+  const end = process.memoryUsage().heapUsed;
+  performance.mark('mem-end');
+  performance.measure('memory-leak', 'mem-start', 'mem-end');
+  const [measure] = performance.getEntriesByName('memory-leak');
+  performance.clearMarks();
+  performance.clearMeasures();
+  return {
+    result,
+    leak: end - start,
+    duration: measure.duration
+  };
+}
+
+module.exports = { withMemoryLeakCheck };

--- a/scripts/ui-stress.js
+++ b/scripts/ui-stress.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+const { withMemoryLeakCheck } = require('./harness');
+
+async function openWindows(browser, count = 3) {
+  let totalFps = 0;
+  const longTasks = [];
+
+  for (let i = 0; i < count; i++) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 800 + i * 50, height: 600 + i * 50 });
+    await page.goto('about:blank');
+    await page.evaluate(() => {
+      const btn = document.createElement('button');
+      btn.id = 'btn';
+      btn.textContent = 'click';
+      document.body.appendChild(btn);
+      btn.addEventListener('click', () => {});
+    });
+    await page.click('#btn');
+
+    const metrics = await page.evaluate(() => {
+      return new Promise(resolve => {
+        const longTasks = [];
+        new PerformanceObserver(list => {
+          longTasks.push(...list.getEntries().map(e => e.duration));
+        }).observe({ type: 'longtask', buffered: true });
+
+        let frames = 0;
+        const start = performance.now();
+        function frame(now) {
+          frames++;
+          if (now - start > 1000) {
+            resolve({
+              fps: frames / ((now - start) / 1000),
+              longTasks
+            });
+          } else {
+            requestAnimationFrame(frame);
+          }
+        }
+        requestAnimationFrame(frame);
+      });
+    });
+
+    totalFps += metrics.fps;
+    longTasks.push(...metrics.longTasks);
+    await page.close();
+  }
+
+  return { frameRate: totalFps / count, longTasks };
+}
+
+async function run() {
+  const browser = await puppeteer.launch();
+  const { result, leak, duration } = await withMemoryLeakCheck(() => openWindows(browser));
+  await browser.close();
+
+  const report = {
+    frameRate: result.frameRate,
+    longTasks: result.longTasks,
+    memory: { leak, duration }
+  };
+
+  fs.mkdirSync('reports', { recursive: true });
+  fs.writeFileSync('reports/ui-stress.json', JSON.stringify(report, null, 2));
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- script to open multiple browser windows, resize, and interact
- harness using `performance.measure` to report potential memory leaks
- sample report path for frame rate and long tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6656648328bdc2c79f5e617712