### PR TITLE
feat: add layout-aware shortcut registry

### DIFF
--- a/src/components/ShortcutHelp.tsx
+++ b/src/components/ShortcutHelp.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { registry, formatShortcut } from '../shortcuts/registry';
+import { getLayout, Layout } from '../utils/metaKey';
+
+const layout: Layout = getLayout();
+
+const ShortcutHelp: React.FC = () => (
+  <div>
+    {Object.entries(registry).map(([id, shortcut]) => (
+      <div key={id}>
+        <span>{shortcut.description}</span>
+        <kbd>{formatShortcut(id, layout)}</kbd>
+      </div>
+    ))}
+  </div>
+);
+
+export default ShortcutHelp;

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -1,0 +1,34 @@
+import { Layout, metaKey } from '../utils/metaKey';
+
+export interface Shortcut {
+  description: string;
+  keys: string[];
+}
+
+export const registry: Record<string, Shortcut> = {
+  openHelp: {
+    description: 'Open shortcut help',
+    keys: ['Meta', '/'],
+  },
+};
+
+const normalizeKey = (key: string, layout: Layout): string => {
+  switch (key.toLowerCase()) {
+    case 'meta':
+      return metaKey(layout);
+    case 'alt':
+      return layout === 'mac' ? 'Option' : 'Alt';
+    case 'shift':
+      return 'Shift';
+    case 'ctrl':
+      return 'Ctrl';
+    default:
+      return key;
+  }
+};
+
+export const formatShortcut = (id: string, layout: Layout): string => (
+  registry[id]
+    ? registry[id].keys.map((k) => normalizeKey(k, layout)).join('+')
+    : ''
+);

--- a/src/utils/metaKey.ts
+++ b/src/utils/metaKey.ts
@@ -1,0 +1,17 @@
+export type Layout = 'mac' | 'windows';
+
+const MAC_PLATFORMS = ['mac', 'iphone', 'ipod', 'ipad'];
+
+export const getLayout = (): Layout => {
+  if (typeof navigator === 'undefined') {
+    return 'windows';
+  }
+  const platform = navigator.platform.toLowerCase();
+  return MAC_PLATFORMS.some((p) => platform.includes(p))
+    ? 'mac'
+    : 'windows';
+};
+
+export const metaKey = (layout: Layout = getLayout()): string => (
+  layout === 'mac' ? '⌘' : 'Ctrl'
+);


### PR DESCRIPTION
## Summary
- add registry for keyboard shortcuts with layout-specific modifier resolution
- detect platform meta key for macOS and Windows
- render layout-specific shortcut keys in help panel component

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a69ce908328bccd8001f23b9841