### PR TITLE
feat: add paste sanitizer and settings

### DIFF
--- a/src/dev/PasteLogger.ts
+++ b/src/dev/PasteLogger.ts
@@ -1,0 +1,6 @@
+export default function pasteLogger(strippedElements: string[]): void {
+  if (strippedElements.length) {
+    // eslint-disable-next-line no-console
+    console.debug('Stripped elements:', strippedElements.join(', '));
+  }
+}

--- a/src/pages/settings/editor.tsx
+++ b/src/pages/settings/editor.tsx
@@ -1,0 +1,18 @@
+(() => {
+  const checkbox = document.querySelector<HTMLInputElement>('#plainTextPaste');
+  if (!checkbox) {
+    return;
+  }
+
+  const stored = localStorage.getItem('plainTextPaste');
+  if (stored === null) {
+    checkbox.checked = true;
+    localStorage.setItem('plainTextPaste', 'true');
+  } else {
+    checkbox.checked = stored === 'true';
+  }
+
+  checkbox.addEventListener('change', () => {
+    localStorage.setItem('plainTextPaste', String(checkbox.checked));
+  });
+})();

--- a/src/utils/htmlSanitizer.ts
+++ b/src/utils/htmlSanitizer.ts
@@ -1,0 +1,24 @@
+import pasteLogger from '../dev/PasteLogger';
+
+export interface SanitizationResult {
+  sanitizedHtml: string;
+  strippedElements: string[];
+}
+
+export default class HtmlSanitizer {
+  static sanitize(html: string): SanitizationResult {
+    const strippedElements: string[] = [];
+
+    const sanitizedHtml = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, (_match, tag) => {
+      strippedElements.push((tag as string).toLowerCase());
+      return '';
+    });
+
+    pasteLogger(strippedElements);
+
+    return {
+      sanitizedHtml,
+      strippedElements,
+    };
+  }
+}

--- a/tests/utils/htmlSanitizer.test.ts
+++ b/tests/utils/htmlSanitizer.test.ts
@@ -1,0 +1,11 @@
+import HtmlSanitizer from '../../src/utils/htmlSanitizer';
+
+describe('htmlSanitizer', () => {
+  it('strips style and script tags', () => {
+    const input = '<div>text<style>.a{}</style><script>alert(1)</script></div>';
+    const { sanitizedHtml, strippedElements } = HtmlSanitizer.sanitize(input);
+
+    expect(sanitizedHtml).toBe('<div>text</div>');
+    expect(strippedElements).toEqual(['style', 'script']);
+  });
+});


### PR DESCRIPTION
## Summary
- strip script and style tags via new HTML sanitizer
- log stripped tags during development for paste debugging
- default paste behavior to plain text with new settings script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6a0f648328b072df6b6fe6c0c9