### PR TITLE
feat: add timezone shift detection and dual-time events

### DIFF
--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -1,0 +1,21 @@
+export interface Event {
+  id: string;
+  title: string;
+  /** Canonical event time in UTC. */
+  canonicalTime: Date;
+  /** Event time in the user's local timezone. */
+  localTime: Date;
+}
+
+/**
+ * Creates an event capturing both the canonical UTC time and the local time
+ * of the user when the event was scheduled.
+ */
+export function createEvent(
+  id: string,
+  title: string,
+  localTime: Date,
+): Event {
+  const canonicalTime = new Date(localTime.getTime() + localTime.getTimezoneOffset() * 60_000);
+  return { id, title, canonicalTime, localTime };
+}

--- a/src/pages/calendar/EventDualTime.tsx
+++ b/src/pages/calendar/EventDualTime.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Event } from '../../models/Event';
+
+export interface EventDualTimeProps {
+  event: Event;
+}
+
+/**
+ * Shows an event's time in both local and canonical (UTC) formats.
+ */
+export const EventDualTime: React.FC<EventDualTimeProps> = ({ event }) => (
+  <div className="event-dual-time">
+    <div className="event-time-local">{event.localTime.toLocaleString()}</div>
+    <div className="event-time-canonical">{event.canonicalTime.toUTCString()}</div>
+  </div>
+);
+
+export default EventDualTime;

--- a/src/utils/timezoneWatcher.ts
+++ b/src/utils/timezoneWatcher.ts
@@ -1,0 +1,41 @@
+export type TimezoneChangeCallback = (previousOffset: number, currentOffset: number) => void;
+
+/**
+ * Watches for large timezone offset changes and notifies the user so they can
+ * adjust event times or other time sensitive data.
+ *
+ * @param thresholdMinutes Minimum difference in minutes considered a shift.
+ * @param cb Callback executed when the shift is detected.
+ * @returns A function that stops watching when called.
+ */
+export function watchTimezone(
+  thresholdMinutes: number,
+  cb?: TimezoneChangeCallback,
+): () => void {
+  let lastOffset = new Date().getTimezoneOffset();
+  const callback = cb ?? defaultPrompt;
+  const interval = setInterval(() => {
+    const offset = new Date().getTimezoneOffset();
+    if (Math.abs(offset - lastOffset) >= thresholdMinutes) {
+      callback(lastOffset, offset);
+      lastOffset = offset;
+    }
+  }, 60_000);
+  return () => clearInterval(interval);
+}
+
+function defaultPrompt(previous: number, current: number): void {
+  if (typeof window !== 'undefined') {
+    const message = `Timezone changed from UTC${formatOffset(previous)} to UTC${formatOffset(current)}. Please adjust your settings.`;
+    // eslint-disable-next-line no-alert
+    window.alert(message);
+  }
+}
+
+function formatOffset(offset: number): string {
+  const sign = offset > 0 ? '-' : '+';
+  const abs = Math.abs(offset);
+  const hours = String(Math.floor(abs / 60)).padStart(2, '0');
+  const minutes = String(abs % 60).padStart(2, '0');
+  return `${sign}${hours}:${minutes}`;
+}


### PR DESCRIPTION
## Summary
- detect timezone shifts and alert user
- add event model storing canonical & local times
- show events in both local and UTC time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6c52108328a1613cc838c8a29a