### PR TITLE
feat: add search synonym and telemetry support

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!search/
+!search/**

--- a/data/search/synonyms.json
+++ b/data/search/synonyms.json
@@ -1,0 +1,5 @@
+{
+  "javascript": ["js", "node"],
+  "repository": ["repo", "repos", "repositories"],
+  "typescript": ["ts", "type-script"]
+}

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,0 +1,35 @@
+import stem from '../search/stemmer';
+import logZeroResult from '../metrics/searchTelemetry';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const synonyms: Record<string, string[]> = require('../../data/search/synonyms.json');
+
+export interface SearchResponse {
+  results: string[];
+  suggestion: string | null;
+}
+
+export function suggestCorrection(query: string): string | null {
+  const stemmed = stem(query);
+  for (const [canonical, syns] of Object.entries(synonyms)) {
+    if (canonical === stemmed || syns.includes(stemmed)) {
+      return canonical;
+    }
+  }
+  return null;
+}
+
+export function searchWithSuggestions(
+  query: string,
+  searchFn: (q: string) => string[],
+): SearchResponse {
+  const suggestion = suggestCorrection(query);
+  const toSearch = suggestion ?? query;
+  const results = searchFn(toSearch);
+
+  if (results.length === 0) {
+    logZeroResult(query);
+  }
+
+  return { results, suggestion };
+}

--- a/src/metrics/searchTelemetry.ts
+++ b/src/metrics/searchTelemetry.ts
@@ -1,0 +1,4 @@
+export default function logZeroResult(query: string): void {
+  // In a real application, replace this with actual telemetry integration.
+  console.warn(`Zero search results for query: "${query}"`);
+}

--- a/src/search/stemmer.ts
+++ b/src/search/stemmer.ts
@@ -1,0 +1,15 @@
+export default function stem(word: string): string {
+  let result = word.toLowerCase();
+  if (result.endsWith('ies')) {
+    result = `${result.slice(0, -3)}y`;
+  } else if (result.endsWith('ing')) {
+    result = result.slice(0, -3);
+  } else if (result.endsWith('ed')) {
+    result = result.slice(0, -2);
+  } else if (result.endsWith('es')) {
+    result = result.slice(0, -2);
+  } else if (result.endsWith('s') && result.length > 1) {
+    result = result.slice(0, -1);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add search synonyms list and stemming rules
- suggest corrected queries in search box
- log zero-result searches to telemetry

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6d1b2c832897fe027073c9cc83