### PR TITLE
feat: add print preview and pdf export

### DIFF
--- a/src/components/SaveAsPdfButton.tsx
+++ b/src/components/SaveAsPdfButton.tsx
@@ -1,0 +1,14 @@
+import inlineAssets from '../utils/inlineAssets';
+
+export default function SaveAsPdfButton(): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = 'Save as PDF';
+
+  button.addEventListener('click', async () => {
+    await inlineAssets();
+    window.print();
+  });
+
+  return button;
+}

--- a/src/pages/print/Preview.tsx
+++ b/src/pages/print/Preview.tsx
@@ -1,0 +1,28 @@
+export default function Preview(): void {
+  const style = document.createElement('style');
+  style.innerHTML = `
+    @media print {
+      @page {
+        size: A4;
+        margin: 20mm;
+      }
+
+      body {
+        margin: 0;
+      }
+    }
+
+    .page-preview {
+      width: 210mm;
+      min-height: 297mm;
+      margin: 0 auto;
+      box-sizing: border-box;
+      background: #fff;
+    }
+  `;
+  document.head.appendChild(style);
+
+  const preview = document.createElement('div');
+  preview.className = 'page-preview';
+  document.body.appendChild(preview);
+}

--- a/src/pages/print/index.ts
+++ b/src/pages/print/index.ts
@@ -1,0 +1,6 @@
+import Preview from './Preview'; // eslint-disable-line import/extensions
+import SaveAsPdfButton from '../../components/SaveAsPdfButton'; // eslint-disable-line import/extensions
+
+Preview();
+
+document.body.appendChild(SaveAsPdfButton());

--- a/src/utils/inlineAssets.ts
+++ b/src/utils/inlineAssets.ts
@@ -1,0 +1,37 @@
+async function toDataUrl(src: string): Promise<string> {
+  const response = await fetch(src);
+  const blob = await response.blob();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = () => resolve(reader.result as string);
+    reader.readAsDataURL(blob);
+  });
+}
+
+export default async function inlineAssets(): Promise<void> {
+  const images: (HTMLImageElement | SVGImageElement)[] = [
+    ...Array.from(document.querySelectorAll<HTMLImageElement>('img[src]')),
+    ...Array.from(document.querySelectorAll<SVGImageElement>('svg image[href], svg image[xlink\\:href]')),
+  ];
+
+  await Promise.all(images.map(async (element) => {
+    const el = element;
+    const src = el instanceof SVGImageElement ? el.href.baseVal : el.src;
+    if (!src || src.startsWith('data:')) {
+      return;
+    }
+
+    try {
+      const dataUrl = await toDataUrl(src);
+      if (el instanceof SVGImageElement) {
+        el.setAttribute('href', dataUrl);
+        el.setAttribute('xlink:href', dataUrl);
+      } else {
+        (el as HTMLImageElement).src = dataUrl;
+      }
+    } catch (e) {
+      // ignore fetch errors
+    }
+  }));
+}


### PR DESCRIPTION
## Summary
- add print preview page with page size and margins
- inline images before printing for logos and icons
- add Save as PDF button that prepares print layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6ec2e883288adef56a16dc59f0