### PR TITLE
Add speech transcription, voice note player, and TTS quiet mode

### DIFF
--- a/src/components/VoiceNotePlayer.tsx
+++ b/src/components/VoiceNotePlayer.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef, useState } from 'react';
+import transcribe from '../speech/transcribe';
+
+interface VoiceNotePlayerProps {
+  src: string;
+  showCaption?: boolean;
+}
+
+const VoiceNotePlayer: React.FC<VoiceNotePlayerProps> = ({ src, showCaption = true }) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [caption, setCaption] = useState('');
+
+  const togglePlayback = (): void => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+    if (audio.paused) {
+      void audio.play();
+      setPlaying(true);
+    } else {
+      audio.pause();
+      setPlaying(false);
+    }
+  };
+
+  useEffect(() => {
+    let active = true;
+    async function run() {
+      if (showCaption) {
+        try {
+          const text = await transcribe();
+          if (active && text) {
+            setCaption(text);
+          }
+        } catch {
+          // ignore transcription errors
+        }
+      }
+    }
+    run();
+    return () => {
+      active = false;
+    };
+  }, [src, showCaption]);
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('audio', { ref: audioRef, src }),
+    React.createElement(
+      'button',
+      { type: 'button', onClick: togglePlayback },
+      playing ? 'Pause' : 'Play',
+    ),
+    showCaption && caption ? React.createElement('p', null, caption) : null,
+  );
+};
+
+export default VoiceNotePlayer;

--- a/src/speech/transcribe.ts
+++ b/src/speech/transcribe.ts
@@ -1,0 +1,52 @@
+export interface TranscribeOptions {
+  lang?: string;
+}
+
+export const transcribe = async (
+  options: TranscribeOptions = {},
+): Promise<string | null> => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const { lang = 'en-US' } = options;
+  const SpeechRecognition = (window as any).SpeechRecognition
+    || (window as any).webkitSpeechRecognition;
+
+  if (!SpeechRecognition || !navigator.permissions) {
+    return null;
+  }
+
+  try {
+    const permissionStatus = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+
+    if (permissionStatus.state !== 'granted') {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return new Promise((resolve, reject) => {
+    const recognition = new SpeechRecognition();
+    recognition.lang = lang;
+    recognition.maxAlternatives = 1;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript = Array.from(event.results)
+        .map((result) => result[0].transcript)
+        .join(' ');
+      resolve(transcript);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      reject(event.error);
+    };
+
+    recognition.start();
+  });
+};
+
+export default transcribe;

--- a/src/speech/tts.ts
+++ b/src/speech/tts.ts
@@ -1,0 +1,24 @@
+export interface SpeakOptions {
+  lang?: string;
+  quiet?: boolean;
+}
+
+export const speakSuccess = (
+  message: string,
+  options: SpeakOptions = {},
+): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const { quiet = false, lang = 'en-US' } = options;
+  if (quiet || !('speechSynthesis' in window)) {
+    return;
+  }
+
+  const utterance = new SpeechSynthesisUtterance(message);
+  utterance.lang = lang;
+  window.speechSynthesis.speak(utterance);
+};
+
+export default speakSuccess;


### PR DESCRIPTION
## Summary
- add speech transcription gated by microphone permission
- enable text-to-speech for success messages with quiet option
- create voice note player component with playback and captions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a6f204083289aaf3955027cbbaf