### PR TITLE
chore: add release smoke checks

### DIFF
--- a/reports/env-snapshot.json
+++ b/reports/env-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "NODE_ENV": null,
+  "CI": null,
+  "PLATFORM": "linux",
+  "NODE_VERSION": "v20.19.4"
+}

--- a/reports/release-smoke.json
+++ b/reports/release-smoke.json
@@ -1,0 +1,6 @@
+{
+  "unit": { "status": "passed" },
+  "e2e": { "status": "skipped" },
+  "a11y": { "status": "skipped" },
+  "perf": { "status": "skipped" }
+}

--- a/scripts/checkReleaseSmoke.ts
+++ b/scripts/checkReleaseSmoke.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+
+interface GateResult {
+  status: 'passed' | 'failed' | 'skipped';
+  [key: string]: any;
+}
+
+interface ReleaseSmoke {
+  [gate: string]: GateResult;
+}
+
+const file = process.argv[2] || 'reports/release-smoke.json';
+const data = JSON.parse(fs.readFileSync(file, 'utf8')) as ReleaseSmoke;
+
+let hasFailure = false;
+for (const [gate, result] of Object.entries(data)) {
+  if (result.status !== 'passed') {
+    console.error(`Gate "${gate}" did not pass (status: ${result.status}).`);
+    hasFailure = true;
+  } else {
+    console.log(`Gate "${gate}" passed.`);
+  }
+}
+
+if (hasFailure) {
+  console.error('Release smoke check failed.');
+  process.exit(1);
+} else {
+  console.log('All release smoke checks passed.');
+}


### PR DESCRIPTION
## Summary
- add release smoke test report and environment snapshot
- check release smoke report to block promotions on failed gates

## Testing
- `npm test`
- `npx ts-node scripts/checkReleaseSmoke.ts` *(fails: Gate "e2e" did not pass (status: skipped))*

------
https://chatgpt.com/codex/tasks/task_e_68b46a70abd88328b8a04add2ce4a171