### PR TITLE
feat: add feature detection with fallbacks

### DIFF
--- a/src/components/fallbacks/fetch.ts
+++ b/src/components/fallbacks/fetch.ts
@@ -1,0 +1,3 @@
+export default function fetchFallback() {
+  return 'fetch fallback';
+}

--- a/src/components/fallbacks/localStorage.ts
+++ b/src/components/fallbacks/localStorage.ts
@@ -1,0 +1,3 @@
+export default function localStorageFallback() {
+  return 'localStorage fallback';
+}

--- a/src/components/fallbacks/serviceWorker.ts
+++ b/src/components/fallbacks/serviceWorker.ts
@@ -1,0 +1,3 @@
+export default function serviceWorkerFallback() {
+  return 'serviceWorker fallback';
+}

--- a/src/utils/featureMatrix.ts
+++ b/src/utils/featureMatrix.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+
+export interface Capabilities {
+  fetch: boolean;
+  serviceWorker: boolean;
+  localStorage: boolean;
+}
+
+export const FEATURES: (keyof Capabilities)[] = ['fetch', 'serviceWorker', 'localStorage'];
+
+export function detectFeatures(env: any = globalThis): Capabilities {
+  return {
+    fetch: typeof env.fetch === 'function',
+    serviceWorker: typeof env.navigator !== 'undefined' && 'serviceWorker' in env.navigator,
+    localStorage: typeof env.localStorage !== 'undefined',
+  };
+}
+
+export function getBrowser(userAgent?: string): string {
+  const ua = userAgent || (typeof navigator !== 'undefined' ? navigator.userAgent : '');
+  if (/firefox/i.test(ua)) {
+    return 'firefox';
+  }
+  if (/chrome|chromium|crios/i.test(ua)) {
+    return 'chrome';
+  }
+  if (/safari/i.test(ua)) {
+    return 'safari';
+  }
+  return 'unknown';
+}
+
+export function featureMatrix(env: any = globalThis): { [browser: string]: Capabilities } {
+  const browser = getBrowser(env.navigator?.userAgent);
+  return { [browser]: detectFeatures(env) };
+}
+
+export function loadFallbacks(features: Capabilities, dir: string = path.join(__dirname, '../components/fallbacks')): any[] {
+  const loaded: any[] = [];
+  Object.entries(features).forEach(([feature, supported]) => {
+    if (!supported) {
+      try {
+        // eslint-disable-next-line global-require, import/no-dynamic-require
+        const mod = require(path.join(dir, feature));
+        loaded.push(mod.default || mod);
+      } catch (e) {
+        // ignore missing fallback
+      }
+    }
+  });
+  return loaded;
+}

--- a/tests/compat/lowCapability.test.ts
+++ b/tests/compat/lowCapability.test.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+import { detectFeatures, featureMatrix, loadFallbacks } from '../../src/utils/featureMatrix';
+
+describe('low capability environment', () => {
+  it('detects missing features and loads fallbacks', () => {
+    const env: any = { navigator: { userAgent: '' } };
+    const features = detectFeatures(env);
+    expect(features).toEqual({ fetch: false, serviceWorker: false, localStorage: false });
+
+    const matrix = featureMatrix(env);
+    expect(matrix).toEqual({ unknown: { fetch: false, serviceWorker: false, localStorage: false } });
+
+    const loaded = loadFallbacks(features, path.join(__dirname, '../../src/components/fallbacks'));
+    const names = loaded.map((fn: any) => fn());
+    expect(names.sort()).toEqual(['fetch fallback', 'serviceWorker fallback', 'localStorage fallback'].sort());
+  });
+});


### PR DESCRIPTION
## Summary
- detect runtime capabilities and build a feature matrix per browser
- auto load fallback components when features are missing
- test low capability environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a7103c483288efd17492719d332