### PR TITLE
feat: add snapshot timeline and revert

### DIFF
--- a/src/components/FormSaveTimeline.tsx
+++ b/src/components/FormSaveTimeline.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import {
+  getSnapshots,
+  subscribe,
+  Snapshot,
+} from '../utils/snapshotStore';
+import RevertSnapshotButton from './RevertSnapshotButton';
+
+interface Props {
+  onRestore?: (data: unknown) => void;
+}
+
+const FormSaveTimeline: React.FC<Props> = ({ onRestore }) => {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>(getSnapshots());
+
+  useEffect(() => {
+    const unsubscribe = subscribe(() => {
+      setSnapshots(getSnapshots());
+    });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <ul>
+      {snapshots.map((snapshot) => (
+        <li key={snapshot.id}>
+          <span>{new Date(snapshot.createdAt).toLocaleString()}</span>
+          <RevertSnapshotButton id={snapshot.id} onRestore={onRestore} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FormSaveTimeline;

--- a/src/components/RevertSnapshotButton.tsx
+++ b/src/components/RevertSnapshotButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { restoreSnapshot } from '../utils/snapshotStore';
+
+interface Props {
+  id: string;
+  onRestore?: (data: unknown) => void;
+}
+
+const RevertSnapshotButton: React.FC<Props> = ({ id, onRestore }) => {
+  const handleClick = (): void => {
+    const data = restoreSnapshot(id);
+    if (onRestore && data !== undefined) {
+      onRestore(data);
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleClick}>
+      Revert
+    </button>
+  );
+};
+
+export default RevertSnapshotButton;

--- a/src/utils/snapshotStore.ts
+++ b/src/utils/snapshotStore.ts
@@ -1,0 +1,75 @@
+export interface Snapshot<T = unknown> {
+  id: string;
+  data: T;
+  createdAt: number;
+}
+
+const STORAGE_KEY = 'snapshots';
+const MAX_SNAPSHOTS = 20;
+
+const listeners: Array<() => void> = [];
+
+function load(): Snapshot[] {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        return JSON.parse(raw) as Snapshot[];
+      } catch {
+        return [];
+      }
+    }
+  }
+  return [];
+}
+
+let snapshots: Snapshot[] = load();
+
+function save(): void {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshots));
+  }
+}
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function purgeSnapshots(limit: number = MAX_SNAPSHOTS): void {
+  if (snapshots.length > limit) {
+    snapshots = snapshots.slice(snapshots.length - limit);
+    save();
+  }
+}
+
+export function addSnapshot<T>(data: T): string {
+  const snapshot: Snapshot<T> = {
+    id: Date.now().toString(),
+    data,
+    createdAt: Date.now(),
+  };
+  snapshots.push(snapshot);
+  purgeSnapshots();
+  save();
+  emit();
+  return snapshot.id;
+}
+
+export function getSnapshots(): Snapshot[] {
+  return [...snapshots];
+}
+
+export function restoreSnapshot<T>(id: string): T | undefined {
+  const snapshot = snapshots.find((s) => s.id === id);
+  return snapshot?.data as T | undefined;
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index >= 0) {
+      listeners.splice(index, 1);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add snapshot store with automatic purge of old entries
- introduce snapshot timeline component
- add button to revert to a saved snapshot

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a7418a88328b78ba50703dcd1f3