### PR TITLE
Add HTML sanitizer and external link component

### DIFF
--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+type Props = React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+const ExternalLink: React.FC<Props> = ({ children, ...props }) => (
+  <a target="_blank" rel="noopener noreferrer" {...props}>
+    {children}
+    <span aria-hidden="true">↗</span>
+  </a>
+);
+
+export default ExternalLink;

--- a/src/utils/safeHtml.ts
+++ b/src/utils/safeHtml.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { JSDOM } = require('jsdom');
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const ALLOWED_TAGS = new Set([
+  'a',
+  'b',
+  'br',
+  'code',
+  'em',
+  'i',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'strong',
+  'ul',
+]);
+
+const ALLOWED_ATTRIBUTES: Record<string, Set<string>> = {
+  a: new Set(['href', 'target', 'rel']),
+};
+
+function clean(node: Element): void {
+  const children = Array.from(node.children);
+  for (const child of children) {
+    const tag = child.tagName.toLowerCase();
+    if (!ALLOWED_TAGS.has(tag)) {
+      child.remove();
+      continue;
+    }
+
+    const allowedAttr = ALLOWED_ATTRIBUTES[tag] ?? new Set();
+    for (const attr of Array.from(child.attributes)) {
+      if (!allowedAttr.has(attr.name)) {
+        child.removeAttribute(attr.name);
+      }
+    }
+
+    if (tag === 'a' && child.hasAttribute('href')) {
+      const href = child.getAttribute('href') || '';
+      if (!/^(https?:|mailto:)/i.test(href)) {
+        child.removeAttribute('href');
+      }
+    }
+
+    clean(child);
+  }
+}
+
+export default function safeHtml(dirty: string): string {
+  const dom = new JSDOM(`<body>${dirty}</body>`);
+  const { document } = dom.window;
+  const body = document.body;
+  clean(body);
+  return body.innerHTML;
+}

--- a/tests/security/safeHtml.test.ts
+++ b/tests/security/safeHtml.test.ts
@@ -1,0 +1,18 @@
+import safeHtml from '../../src/utils/safeHtml';
+
+describe('safeHtml', () => {
+  it('removes script tags', () => {
+    const html = '<p>hello</p><script>alert(1)</script>';
+    expect(safeHtml(html)).toBe('<p>hello</p>');
+  });
+
+  it('removes img tags', () => {
+    const html = '<p>hello</p><img src="x" onerror="alert(1)">';
+    expect(safeHtml(html)).toBe('<p>hello</p>');
+  });
+
+  it('strips disallowed attributes', () => {
+    const html = '<a href="https://example.com" onclick="alert(1)">link</a>';
+    expect(safeHtml(html)).toBe('<a href="https://example.com">link</a>');
+  });
+});


### PR DESCRIPTION
## Summary
- add allowlist-based HTML sanitizer
- add ExternalLink component with external indicator
- test sanitizer to block unsafe tags and attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a75a2508328b5169a8e1a27e13e