### PR TITLE
feat: add DPI aware utilities and tests

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  profile?: string;
+  rendering?: 'auto' | 'crisp-edges' | 'pixelated';
+}
+
+export default function Image({ profile, rendering = 'auto', style, ...props }: ImageProps): JSX.Element {
+  const mergedStyle: React.CSSProperties = { imageRendering: rendering, ...style };
+
+  if (profile) {
+    (mergedStyle as any).colorProfile = profile;
+  }
+
+  return <img {...props} style={mergedStyle} />;
+}
+

--- a/src/utils/dpiAware.ts
+++ b/src/utils/dpiAware.ts
@@ -1,0 +1,43 @@
+export default class DpiAware {
+  static getCssPixelRatio(): number {
+    if (typeof window !== 'undefined' && window.devicePixelRatio) {
+      return window.devicePixelRatio;
+    }
+
+    if (typeof global !== 'undefined' && (global as any).devicePixelRatio) {
+      return (global as any).devicePixelRatio;
+    }
+
+    return 1;
+  }
+
+  static scaleCanvas(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D): void {
+    const ratio = DpiAware.getCssPixelRatio();
+    const { width, height } = canvas;
+
+    // Preserve original display size
+    if (canvas.style) {
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    }
+
+    canvas.width = Math.floor(width * ratio);
+    canvas.height = Math.floor(height * ratio);
+
+    context.scale(ratio, ratio);
+  }
+
+  static scaleImage(img: HTMLImageElement): void {
+    const ratio = DpiAware.getCssPixelRatio();
+    const { width, height } = img;
+
+    if (img.style) {
+      img.style.width = `${width}px`;
+      img.style.height = `${height}px`;
+    }
+
+    img.width = Math.floor(width * ratio);
+    img.height = Math.floor(height * ratio);
+  }
+}
+

--- a/tests/visual/__snapshots__/dpi.test.ts.snap
+++ b/tests/visual/__snapshots__/dpi.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dpiAware retina display 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      2,
+      2,
+    ],
+  ],
+  "canvas": Object {
+    "height": 100,
+    "style": Object {
+      "height": "50px",
+      "width": "100px",
+    },
+    "width": 200,
+  },
+  "ratio": 2,
+}
+`;
+
+exports[`dpiAware standard display 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      1,
+      1,
+    ],
+  ],
+  "canvas": Object {
+    "height": 50,
+    "style": Object {
+      "height": "50px",
+      "width": "100px",
+    },
+    "width": 100,
+  },
+  "ratio": 1,
+}
+`;

--- a/tests/visual/dpi.test.ts
+++ b/tests/visual/dpi.test.ts
@@ -1,0 +1,36 @@
+import DpiAware from '../../src/utils/dpiAware';
+
+describe('dpiAware', () => {
+  function createCanvas() {
+    return { width: 100, height: 50, style: {} } as any as HTMLCanvasElement;
+  }
+
+  function createContext() {
+    return { scale: jest.fn() } as any as CanvasRenderingContext2D;
+  }
+
+  it('standard display', () => {
+    (global as any).window = { devicePixelRatio: 1 };
+    const canvas = createCanvas();
+    const ctx = createContext();
+    DpiAware.scaleCanvas(canvas, ctx);
+    expect({
+      ratio: DpiAware.getCssPixelRatio(),
+      canvas,
+      calls: (ctx.scale as any).mock.calls,
+    }).toMatchSnapshot();
+  });
+
+  it('retina display', () => {
+    (global as any).window = { devicePixelRatio: 2 };
+    const canvas = createCanvas();
+    const ctx = createContext();
+    DpiAware.scaleCanvas(canvas, ctx);
+    expect({
+      ratio: DpiAware.getCssPixelRatio(),
+      canvas,
+      calls: (ctx.scale as any).mock.calls,
+    }).toMatchSnapshot();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add DpiAware utility to scale canvas and images by CSS pixel ratio
- support color profiles and rendering hints in Image component
- cover DPI scaling with retina and standard display snapshot tests

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b46a7766d8832888f89cab11c43512