### PR TITLE
feat: add animation controls

### DIFF
--- a/scripts/checkAnimationBudget.js
+++ b/scripts/checkAnimationBudget.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const MAX_DURATION_MS = 700;
+
+function walk(dir, fileList = []) {
+  fs.readdirSync(dir).forEach((file) => {
+    const fullPath = path.join(dir, file);
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      walk(fullPath, fileList);
+    } else if (/\.(css|scss|js|ts|tsx)$/.test(file)) {
+      fileList.push(fullPath);
+    }
+  });
+  return fileList;
+}
+
+const rootDir = path.join(__dirname, '..', 'src');
+const files = walk(rootDir);
+const regex = /(\d+(?:\.\d+)?)(ms|s)/g;
+let hasLong = false;
+
+files.forEach((file) => {
+  const content = fs.readFileSync(file, 'utf8');
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    let value = parseFloat(match[1]);
+    if (match[2] === 's') value *= 1000;
+    if (value > MAX_DURATION_MS) {
+      console.log(`${file}: ${match[0]} exceeds ${MAX_DURATION_MS}ms`);
+      hasLong = true;
+    }
+  }
+});
+
+if (hasLong) {
+  process.exit(1);
+}

--- a/src/components/ReduceMotionToggle.tsx
+++ b/src/components/ReduceMotionToggle.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { applyAnimationVariables } from '../theme/animations';
+
+const STORAGE_KEY = 'reduce-motion';
+
+const ReduceMotionToggle: React.FC = () => {
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  });
+
+  useEffect(() => {
+    applyAnimationVariables(enabled);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, String(enabled));
+    }
+  }, [enabled]);
+
+  return (
+    <button type="button" onClick={() => setEnabled((v) => !v)}>
+      {enabled ? 'Enable motion' : 'Reduce motion'}
+    </button>
+  );
+};
+
+export default ReduceMotionToggle;

--- a/src/theme/animations.ts
+++ b/src/theme/animations.ts
@@ -1,0 +1,25 @@
+export const durations = {
+  short: 100,
+  medium: 200,
+  long: 500,
+};
+
+export const easings = {
+  standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
+  accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
+  linear: 'linear',
+};
+
+export const applyAnimationVariables = (reduceMotion = false): void => {
+  const root = document.documentElement;
+  Object.entries(durations).forEach(([name, value]) => {
+    const duration = reduceMotion ? 0 : value;
+    root.style.setProperty(`--animation-duration-${name}`, `${duration}ms`);
+  });
+  Object.entries(easings).forEach(([name, value]) => {
+    root.style.setProperty(`--animation-easing-${name}`, value);
+  });
+};
+
+export default { durations, easings, applyAnimationVariables };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
+    "jsx": "react",
     "noUnusedLocals": true,
     "strict": true,
   },


### PR DESCRIPTION
## Summary
- centralize animation durations and easing in a new theme module
- add script to audit animation duration budgets
- provide a React toggle to disable nonessential motion

## Testing
- `node scripts/checkAnimationBudget.js`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a782b8483288c398532bab9a196