### PR TITLE
Add email template previews and validation utility

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!email-samples/
+!email-samples/*.json

--- a/data/email-samples/reset-password.json
+++ b/data/email-samples/reset-password.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alex",
+  "resetLink": "https://example.com/reset"
+}

--- a/data/email-samples/welcome.json
+++ b/data/email-samples/welcome.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alex",
+  "link": "https://example.com/dashboard"
+}

--- a/src/emails/previews/ResetPassword.tsx
+++ b/src/emails/previews/ResetPassword.tsx
@@ -1,0 +1,28 @@
+// @ts-nocheck
+import React, { useEffect, useState } from 'react';
+import ResetPassword from '../templates/ResetPassword';
+import data from '../../../data/email-samples/reset-password.json';
+
+export default function ResetPasswordPreview() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const match = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+    const update = () => setIsDark(match?.matches);
+    update();
+    match?.addEventListener('change', update);
+    const styles = Array.from(document.querySelectorAll('style'));
+    const hasDark = styles.some((s) => s.innerHTML.includes('prefers-color-scheme: dark'));
+    if (!hasDark) {
+      // eslint-disable-next-line no-console
+      console.warn('No dark mode styles detected');
+    }
+    return () => match?.removeEventListener('change', update);
+  }, []);
+
+  return (
+    <div style={{ background: isDark ? '#000' : '#fff', color: isDark ? '#fff' : '#000', padding: 20 }}>
+      <ResetPassword {...data} />
+    </div>
+  );
+}

--- a/src/emails/previews/WelcomeEmail.tsx
+++ b/src/emails/previews/WelcomeEmail.tsx
@@ -1,0 +1,28 @@
+// @ts-nocheck
+import React, { useEffect, useState } from 'react';
+import WelcomeEmail from '../templates/WelcomeEmail';
+import data from '../../../data/email-samples/welcome.json';
+
+export default function WelcomeEmailPreview() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const match = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+    const update = () => setIsDark(match?.matches);
+    update();
+    match?.addEventListener('change', update);
+    const styles = Array.from(document.querySelectorAll('style'));
+    const hasDark = styles.some((s) => s.innerHTML.includes('prefers-color-scheme: dark'));
+    if (!hasDark) {
+      // eslint-disable-next-line no-console
+      console.warn('No dark mode styles detected');
+    }
+    return () => match?.removeEventListener('change', update);
+  }, []);
+
+  return (
+    <div style={{ background: isDark ? '#000' : '#fff', color: isDark ? '#fff' : '#000', padding: 20 }}>
+      <WelcomeEmail {...data} />
+    </div>
+  );
+}

--- a/src/emails/templates/ResetPassword.tsx
+++ b/src/emails/templates/ResetPassword.tsx
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import React from 'react';
+
+interface ResetPasswordProps {
+  name: string;
+  resetLink: string;
+}
+
+export default function ResetPassword({ name, resetLink }: ResetPasswordProps) {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <style>{`
+          body { font-family: Arial, sans-serif; }
+          a { color: #d73a49; }
+          @media (prefers-color-scheme: dark) {
+            body { background: #000; color: #fff; }
+            a { color: #f85149; }
+          }
+        `}</style>
+      </head>
+      <body>
+        <h1>Password Reset</h1>
+        <p>Hello {name},</p>
+        <p>Click the link below to reset your password:</p>
+        <p>
+          <a href={resetLink}>Reset Password</a>
+        </p>
+        <img src="https://via.placeholder.com/120" alt="Reset illustration" />
+      </body>
+    </html>
+  );
+}

--- a/src/emails/templates/WelcomeEmail.tsx
+++ b/src/emails/templates/WelcomeEmail.tsx
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import React from 'react';
+
+interface WelcomeEmailProps {
+  name: string;
+  link: string;
+}
+
+export default function WelcomeEmail({ name, link }: WelcomeEmailProps) {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <style>{`
+          body { font-family: Arial, sans-serif; }
+          a { color: #0366d6; }
+          @media (prefers-color-scheme: dark) {
+            body { background: #000; color: #fff; }
+            a { color: #58a6ff; }
+          }
+        `}</style>
+      </head>
+      <body>
+        <h1>Welcome, {name}!</h1>
+        <p>Thanks for joining our site.</p>
+        <p>
+          Visit your dashboard:
+          {' '}<a href={link}>Click here</a>
+        </p>
+        <img src="https://via.placeholder.com/100" alt="Placeholder" />
+      </body>
+    </html>
+  );
+}

--- a/src/emails/validate.ts
+++ b/src/emails/validate.ts
@@ -1,0 +1,71 @@
+// Simple email validation utility
+import fs from 'fs';
+
+export interface ValidationResult {
+  html: string;
+  text: string;
+  missingAlt: string[];
+}
+
+function inlineCss(html: string): string {
+  const styleMatch = html.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+  if (!styleMatch) return html;
+  const css = styleMatch[1];
+  let result = html.replace(styleMatch[0], '');
+  const rules = css.match(/([^{]+){([^}]+)}/g) || [];
+  rules.forEach((rule) => {
+    const parts = /([^]{1,}){([^}]+)}/.exec(rule);
+    if (!parts) return;
+    const selector = parts[1].trim();
+    const props = parts[2].trim().replace(/\s+/g, ' ');
+    if (/^[a-zA-Z]+$/.test(selector)) {
+      const regex = new RegExp(`<${selector}([^>]*)>`, 'g');
+      result = result.replace(regex, `<${selector}$1 style="${props}">`);
+    }
+  });
+  return result;
+}
+
+function extractAltWarnings(html: string): string[] {
+  const missing: string[] = [];
+  html.replace(/<img([^>]+)>/g, (match, attrs) => {
+    if (!/alt=/i.test(attrs)) {
+      const src = /src="([^"]+)"/i.exec(attrs);
+      missing.push(src ? src[1] : '');
+    }
+    return match;
+  });
+  return missing;
+}
+
+function toPlainText(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function validateEmail(html: string): ValidationResult {
+  const inlined = inlineCss(html);
+  const missingAlt = extractAltWarnings(inlined);
+  const text = toPlainText(inlined);
+  return { html: inlined, text, missingAlt };
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: ts-node validate.ts <file.html>');
+    process.exit(1);
+  }
+  const html = fs.readFileSync(file, 'utf8');
+  const result = validateEmail(html);
+  if (result.missingAlt.length) {
+    console.warn('Images missing alt text:', result.missingAlt.join(', '));
+  } else {
+    console.log('All images have alt text');
+  }
+  fs.writeFileSync(file.replace(/\.html?$/, '.inline.html'), result.html);
+  fs.writeFileSync(file.replace(/\.html?$/, '.txt'), result.text);
+}


### PR DESCRIPTION
## Summary
- add sample Welcome and Reset Password email templates with dark-mode styles
- create preview components with runtime dark mode checks
- introduce validation script for CSS inlining, alt checks, and plaintext output
- seed example data for previews under `data/email-samples`

## Testing
- `npx eslint --ext .js,.ts .`
- `npx jest`
- `npx ts-node src/emails/validate.ts /tmp/sample.html`

------
https://chatgpt.com/codex/tasks/task_e_68b48d4de8548328b5ecbf70e59b58f5