### PR TITLE
Add SLO monitoring config, synthetic pings, and dashboard

### DIFF
--- a/config/slo.json
+++ b/config/slo.json
@@ -1,0 +1,5 @@
+{
+  "/": { "availability": 0.999, "latency": 1000 },
+  "/about": { "availability": 0.99, "latency": 1500 },
+  "/projects": { "availability": 0.99, "latency": 1500 }
+}

--- a/src/monitoring/SloDashboard.tsx
+++ b/src/monitoring/SloDashboard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface SloThreshold {
+  availability: number;
+  latency: number;
+}
+
+export interface SloStats {
+  availability: number;
+  latency: number;
+}
+
+export interface SloDashboardProps {
+  sloConfig: Record<string, SloThreshold>;
+  stats: Record<string, SloStats>;
+}
+
+const SloDashboard: React.FC<SloDashboardProps> = ({ sloConfig, stats }) => (
+  <table>
+    <thead>
+      <tr>
+        <th>Route</th>
+        <th>Availability</th>
+        <th>Latency (ms)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {Object.entries(sloConfig).map(([route, threshold]) => {
+        const current = stats[route] || { availability: 0, latency: Infinity };
+        const atRisk = current.availability < threshold.availability || current.latency > threshold.latency;
+        return (
+          <tr key={route} style={{ color: atRisk ? 'red' : undefined }}>
+            <td>{route}</td>
+            <td>{(current.availability * 100).toFixed(2)}% / {(threshold.availability * 100).toFixed(2)}%</td>
+            <td>{current.latency} / {threshold.latency}</td>
+          </tr>
+        );
+      })}
+    </tbody>
+  </table>
+);
+
+export default SloDashboard;

--- a/tests/synthetic/ping.test.ts
+++ b/tests/synthetic/ping.test.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
+
+describe('synthetic pings', () => {
+  const sloPath = path.resolve(__dirname, '../../config/slo.json');
+  const sloConfig = JSON.parse(fs.readFileSync(sloPath, 'utf8')) as Record<string, { availability: number; latency: number }>;
+  const regions = ['us-east-1', 'eu-west-1', 'ap-south-1'];
+  const baseUrl = 'https://example.com';
+
+  regions.forEach((region) => {
+    describe(`region ${region}`, () => {
+      Object.keys(sloConfig).forEach((route) => {
+        it(`meets latency for route ${route}`, async () => {
+          const start = Date.now();
+          const res = await axios.get(`${baseUrl}${route}`, {
+            validateStatus: () => true,
+          });
+          const latency = Date.now() - start;
+          expect(res.status).toBeLessThan(500);
+          expect(latency).toBeLessThan(sloConfig[route].latency);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- track SLO thresholds per route
- exercise synthetic pings across regions
- display at-risk SLOs in a simple dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48d4d01688328824dc73f906c34ce