### PR TITLE
Add offline editing and sync support

### DIFF
--- a/src/components/OfflineEditor.tsx
+++ b/src/components/OfflineEditor.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+
+export interface OfflineEditorProps {
+  /**
+   * Unique key used to store editor content in localStorage.
+   */
+  storageKey: string;
+  /**
+   * Placeholder text for the textarea element.
+   */
+  placeholder?: string;
+  /**
+   * Called whenever the value changes.
+   */
+  onChange?: (value: string) => void;
+  /**
+   * Disables the textarea when set to true.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * OfflineEditor is a small textarea wrapper that keeps its value in
+ * `localStorage`. This allows users to continue editing content even when
+ * network connectivity is lost. The latest value is restored on mount.
+ */
+const OfflineEditor: React.FC<OfflineEditorProps> = ({
+  storageKey,
+  placeholder,
+  onChange,
+  disabled,
+}) => {
+  const [value, setValue] = useState('');
+
+  // Load value from storage on mount.
+  useEffect(() => {
+    try {
+      const stored = globalThis.localStorage?.getItem(storageKey);
+      if (stored !== null) {
+        setValue(stored);
+      }
+    } catch {
+      // ignore access errors (e.g. in non-browser environments)
+    }
+  }, [storageKey]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    setValue(val);
+    try {
+      globalThis.localStorage?.setItem(storageKey, val);
+    } catch {
+      // ignore write errors
+    }
+    if (onChange) {
+      onChange(val);
+    }
+  };
+
+  return (
+    <textarea
+      value={value}
+      onChange={handleChange}
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  );
+};
+
+export default OfflineEditor;
+

--- a/src/components/SyncConflictDialog.tsx
+++ b/src/components/SyncConflictDialog.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export interface SyncConflictDialogProps {
+  /** Local representation of the item. */
+  local: string;
+  /** Server representation of the item. */
+  remote: string;
+  /**
+   * Callback executed when the user chooses a side of the conflict.
+   * Argument is either `'local'` or `'remote'`.
+   */
+  onChoose: (choice: 'local' | 'remote') => void;
+}
+
+/**
+ * Simple dialog component that displays conflicting versions of a resource and
+ * lets the user decide which one to keep.
+ */
+const SyncConflictDialog: React.FC<SyncConflictDialogProps> = ({ local, remote, onChoose }) => (
+  <div className="sync-conflict-dialog">
+    <div className="conflict-version">
+      <h3>Local version</h3>
+      <pre>{local}</pre>
+      <button type="button" onClick={() => onChoose('local')}>
+        Use Local
+      </button>
+    </div>
+    <div className="conflict-version">
+      <h3>Server version</h3>
+      <pre>{remote}</pre>
+      <button type="button" onClick={() => onChoose('remote')}>
+        Use Server
+      </button>
+    </div>
+  </div>
+);
+
+export default SyncConflictDialog;
+

--- a/src/services/offlineSync.ts
+++ b/src/services/offlineSync.ts
@@ -1,0 +1,100 @@
+export interface OfflineItem {
+  /** Unique identifier of the item. */
+  id: string;
+  /** Timestamp used to resolve conflicts. */
+  updatedAt: number;
+  /** Arbitrary payload. */
+  [key: string]: any;
+}
+
+export type ConflictResolver = (local: OfflineItem, remote: OfflineItem) => OfflineItem;
+
+const STORAGE_KEY = 'offline-drafts';
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+// Fallback storage for non-browser environments (e.g., during tests).
+const memoryStore: Record<string, string> = {};
+const memoryStorage: StorageLike = {
+  getItem: (k) => (k in memoryStore ? memoryStore[k] : null),
+  setItem: (k, v) => {
+    memoryStore[k] = v;
+  },
+  removeItem: (k) => {
+    delete memoryStore[k];
+  },
+};
+
+function getStorage(): StorageLike {
+  const ls = (globalThis as any).localStorage as StorageLike | undefined;
+  return ls ?? memoryStorage;
+}
+
+export function loadOfflineItems(): OfflineItem[] {
+  const storage = getStorage();
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as OfflineItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveOfflineItems(items: OfflineItem[]): void {
+  const storage = getStorage();
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // ignore write errors
+  }
+}
+
+export function addOfflineItem(item: OfflineItem): void {
+  const items = loadOfflineItems();
+  const index = items.findIndex((i) => i.id === item.id);
+  if (index >= 0) {
+    items[index] = item;
+  } else {
+    items.push(item);
+  }
+  saveOfflineItems(items);
+}
+
+/**
+ * Synchronises locally stored items with the server list. The caller provides
+ * functions used to fetch the current server state and to persist the merged
+ * result. A custom conflict resolver can be supplied to decide which side wins
+ * when both local and remote items share the same identifier.
+ */
+export async function syncOfflineItems(
+  fetchServer: () => Promise<OfflineItem[]>,
+  pushServer: (items: OfflineItem[]) => Promise<void>,
+  resolveConflict: ConflictResolver = (local) => local,
+): Promise<OfflineItem[]> {
+  const [localItems, serverItems] = await Promise.all([
+    Promise.resolve(loadOfflineItems()),
+    fetchServer(),
+  ]);
+
+  const merged = new Map<string, OfflineItem>();
+  serverItems.forEach((item) => merged.set(item.id, item));
+
+  localItems.forEach((item) => {
+    const existing = merged.get(item.id);
+    if (existing) {
+      merged.set(item.id, resolveConflict(item, existing));
+    } else {
+      merged.set(item.id, item);
+    }
+  });
+
+  const result = Array.from(merged.values());
+  await pushServer(result);
+  // Clear local drafts on successful sync
+  getStorage().removeItem(STORAGE_KEY);
+  return result;
+}


### PR DESCRIPTION
## Summary
- create `OfflineEditor` component that persists text locally for offline use
- add `syncOfflineItems` utility to merge local drafts with server list
- introduce `SyncConflictDialog` to choose between local and remote versions during conflicts

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b48d51a8948328b3258c5ae02474b9