### PR TITLE
feat: add network-aware rough mode toggle

### DIFF
--- a/src/components/RoughModeBanner.tsx
+++ b/src/components/RoughModeBanner.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface Props {
+  onExit: () => void;
+}
+
+const RoughModeBanner: React.FC<Props> = ({ onExit }) => (
+  <div className="rough-mode-banner">
+    <span>
+      You are browsing in rough mode due to a slow connection.
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          onExit();
+        }}
+      >
+        Switch back
+      </a>
+    </span>
+  </div>
+);
+
+export default RoughModeBanner;

--- a/src/components/RoughModeToggle.tsx
+++ b/src/components/RoughModeToggle.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+import NetworkQuality from '../utils/networkQuality';
+import RoughModeBanner from './RoughModeBanner';
+
+const RoughModeToggle: React.FC = () => {
+  const [roughMode, setRoughMode] = useState(false);
+  const [autoEnabled, setAutoEnabled] = useState(false);
+
+  useEffect(() => {
+    const slow = NetworkQuality.isSlow();
+    if (slow) {
+      setRoughMode(true);
+      setAutoEnabled(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.body.classList.toggle('rough-mode', roughMode);
+    }
+  }, [roughMode]);
+
+  const toggle = () => setRoughMode((prev) => !prev);
+
+  return (
+    <>
+      {autoEnabled && roughMode && (
+        <RoughModeBanner onExit={() => setRoughMode(false)} />
+      )}
+      <button onClick={toggle} type="button">
+        {roughMode ? 'Disable rough mode' : 'Enable rough mode'}
+      </button>
+    </>
+  );
+};
+
+export default RoughModeToggle;

--- a/src/utils/networkQuality.ts
+++ b/src/utils/networkQuality.ts
@@ -1,0 +1,26 @@
+export default class NetworkQuality {
+  static getDownlink(): number {
+    if (typeof navigator === 'undefined' || !(navigator as any).connection) {
+      return 0;
+    }
+
+    const { downlink = 0 } = (navigator as any).connection;
+    return downlink;
+  }
+
+  static isSlow(threshold = 1.5): boolean {
+    const downlink = NetworkQuality.getDownlink();
+    if (downlink && downlink > 0 && downlink < threshold) {
+      return true;
+    }
+
+    if (typeof navigator !== 'undefined' && (navigator as any).connection) {
+      const { saveData, effectiveType } = (navigator as any).connection;
+      if (saveData || effectiveType === 'slow-2g' || effectiveType === '2g') {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/tests/utils/NetworkQuality.test.ts
+++ b/tests/utils/NetworkQuality.test.ts
@@ -1,0 +1,7 @@
+import NetworkQuality from '../../src/utils/networkQuality';
+
+describe('NetworkQuality', () => {
+  it('returns false when connection info unavailable', () => {
+    expect(NetworkQuality.isSlow()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
- add network quality utility using navigator.connection
- add rough mode toggle component with auto-detection and banner
- include basic network quality test

## Testing
- `npx yarn@1.22.19 test`

------
https://chatgpt.com/codex/tasks/task_e_68b48d52575483288d7455538b791f74