### PR TITLE
Add vCard parser worker, CSV import wizard and contact dedupe

### DIFF
--- a/src/components/CsvImportWizard.tsx
+++ b/src/components/CsvImportWizard.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// React is assumed to be available in the execution environment
+// but we declare it here to avoid bundling errors during tests.
+declare const React: any;
+
+type CsvImportWizardProps = {
+  requiredColumns?: string[];
+  onComplete?: (rows: Record<string, string>[]) => void;
+};
+
+const parseCsv = (text: string): { columns: string[]; rows: string[][] } => {
+  const lines = text.trim().split(/\r?\n/).map((l) => l.split(',').map((c) => c.trim()));
+  const columns = lines.shift() || [];
+  return { columns, rows: lines };
+};
+
+const CsvImportWizard = ({ requiredColumns = [], onComplete }: CsvImportWizardProps): any => {
+  const [columns, setColumns] = React.useState<string[]>([]);
+  const [rows, setRows] = React.useState<string[][]>([]);
+  const [errors, setErrors] = React.useState<string[]>([]);
+
+  const handleFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const { columns: cols, rows: csvRows } = parseCsv(String(reader.result));
+      setColumns(cols);
+      setRows(csvRows.slice(0, 5)); // preview first 5 rows
+
+      const missing = requiredColumns.filter((c) => !cols.includes(c));
+      setErrors(missing.map((m) => `Missing column: ${m}`));
+
+      if (missing.length === 0 && onComplete) {
+        const mapped = csvRows.map((row) => {
+          const obj: Record<string, string> = {};
+          cols.forEach((col, idx) => {
+            obj[col] = row[idx];
+          });
+          return obj;
+        });
+        onComplete(mapped);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleChange = (e: any) => {
+    const file: File | undefined = e.target.files && e.target.files[0];
+    if (file) {
+      handleFile(file);
+    }
+  };
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('input', { type: 'file', accept: '.csv', onChange: handleChange }),
+    errors.length > 0 &&
+      React.createElement(
+        'ul',
+        { className: 'errors' },
+        errors.map((err: string) => React.createElement('li', { key: err }, err))
+      ),
+    columns.length > 0 &&
+      React.createElement(
+        'table',
+        null,
+        React.createElement(
+          'thead',
+          null,
+          React.createElement(
+            'tr',
+            null,
+            columns.map((c: string) => React.createElement('th', { key: c }, c))
+          )
+        ),
+        React.createElement(
+          'tbody',
+          null,
+          rows.map((r: string[], i: number) =>
+            React.createElement(
+              'tr',
+              { key: i },
+              r.map((cell: string, j: number) => React.createElement('td', { key: j }, cell))
+            )
+          )
+        )
+      )
+  );
+};
+
+export default CsvImportWizard;

--- a/src/utils/contactDedupe.ts
+++ b/src/utils/contactDedupe.ts
@@ -1,0 +1,48 @@
+export interface Contact {
+  id?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  [key: string]: any;
+}
+
+export interface MergeSuggestion {
+  primary: Contact;
+  duplicates: Contact[];
+  merged: Contact;
+}
+
+export default class ContactDedupe {
+  static findDuplicates(contacts: Contact[]): Contact[][] {
+    const map: { [key: string]: Contact[] } = {};
+    contacts.forEach((contact) => {
+      const key = (contact.email || contact.phone || contact.name || '').toLowerCase();
+      if (!key) {
+        return;
+      }
+      if (!map[key]) {
+        map[key] = [];
+      }
+      map[key].push(contact);
+    });
+    return Object.values(map).filter((group) => group.length > 1);
+  }
+
+  static suggestMerge(group: Contact[]): MergeSuggestion {
+    const primary = group[0];
+    const merged: Contact = { ...primary };
+    for (let i = 1; i < group.length; i += 1) {
+      const c = group[i];
+      Object.keys(c).forEach((k) => {
+        if (merged[k] === undefined && c[k] !== undefined) {
+          merged[k] = c[k];
+        }
+      });
+    }
+    return { primary, duplicates: group.slice(1), merged };
+  }
+
+  static dedupe(contacts: Contact[]): MergeSuggestion[] {
+    return ContactDedupe.findDuplicates(contacts).map((group) => ContactDedupe.suggestMerge(group));
+  }
+}

--- a/src/workers/vcardParser.js
+++ b/src/workers/vcardParser.js
@@ -1,0 +1,59 @@
+/* eslint-env worker */
+/* eslint-disable no-restricted-globals */
+const FIELD_MAP = {
+  FN: 'fullName',
+  EMAIL: 'email',
+  TEL: 'phone',
+  ADR: 'address',
+  ORG: 'organization',
+  TITLE: 'title',
+};
+
+function parseVCard(vcard) {
+  const contact = {};
+
+  if (!vcard || typeof vcard !== 'string') {
+    return contact;
+  }
+
+  vcard.split(/\r?\n/).forEach((line) => {
+    const parts = line.split(':');
+    if (parts.length < 2) {
+      return;
+    }
+
+    const rawKey = parts.shift();
+    const value = parts.join(':');
+
+    if (!rawKey) {
+      return;
+    }
+
+    const key = rawKey.split(';')[0].toUpperCase();
+    const mapped = FIELD_MAP[key];
+
+    if (mapped) {
+      if (contact[mapped]) {
+        if (!Array.isArray(contact[mapped])) {
+          contact[mapped] = [contact[mapped]];
+        }
+        contact[mapped].push(value);
+      } else {
+        contact[mapped] = value;
+      }
+    }
+  });
+
+  return contact;
+}
+
+self.onmessage = (event) => {
+  try {
+    const result = parseVCard(event.data);
+    self.postMessage({ success: true, data: result });
+  } catch (err) {
+    self.postMessage({ success: false, error: err.message });
+  }
+};
+
+export default null;

--- a/tests/utils/contactDedupe.test.ts
+++ b/tests/utils/contactDedupe.test.ts
@@ -1,0 +1,42 @@
+import ContactDedupe, { Contact } from '../../src/utils/contactDedupe';
+
+describe('ContactDedupe', () => {
+  const contacts: Contact[] = [
+    {
+      id: '1',
+      name: 'Alice',
+      email: 'alice@example.com',
+      phone: '123',
+    },
+    {
+      id: '2',
+      name: 'Alice Smith',
+      email: 'alice@example.com',
+    },
+    {
+      id: '3',
+      name: 'Bob',
+      email: 'bob@example.com',
+    },
+  ];
+
+  it('find duplicates by email', () => {
+    const groups = ContactDedupe.findDuplicates(contacts);
+    expect(groups.length).toBe(1);
+    expect(groups[0].length).toBe(2);
+  });
+
+  it('suggest merged contact', () => {
+    const group = ContactDedupe.findDuplicates(contacts)[0];
+    const suggestion = ContactDedupe.suggestMerge(group);
+    expect(suggestion.merged.name).toBe('Alice');
+    expect(suggestion.merged.email).toBe('alice@example.com');
+    expect(suggestion.merged.phone).toBe('123');
+  });
+
+  it('dedupe produces suggestions for all groups', () => {
+    const suggestions = ContactDedupe.dedupe(contacts);
+    expect(suggestions.length).toBe(1);
+    expect(suggestions[0].duplicates.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- parse vCard strings in a Web Worker using a safe field map
- add CSV import wizard with column preview and validation
- detect duplicate contacts and suggest merges

## Testing
- `yarn lint && echo 'Lint passed'`
- `yarn test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b48d52cbbc8328a3b918b7f09e5bf2