### PR TITLE
feat: guard deep links and add fallback

### DIFF
--- a/src/components/DeepLinkFallback.tsx
+++ b/src/components/DeepLinkFallback.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+
+interface Props {
+  /** Message shown to the user when a deep link is rejected */
+  message?: string;
+  /** Optional content to render when falling back */
+  children?: React.ReactNode;
+}
+
+/**
+ * Fallback component used when a deep link cannot be processed safely.
+ * It shows a simple toast (using `alert`) and renders provided children.
+ */
+const DeepLinkFallback: React.FC<Props> = ({ message = 'Invalid or unsafe link', children }) => {
+  useEffect(() => {
+    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+      // Simple toast/notification for environments without dedicated UI libs
+      window.alert(message);
+    }
+  }, [message]);
+
+  return <>{children}</>;
+};
+
+export default DeepLinkFallback;

--- a/src/utils/deepLinkGuard.ts
+++ b/src/utils/deepLinkGuard.ts
@@ -1,0 +1,62 @@
+export interface DeepLinkParams {
+  [key: string]: string;
+}
+
+/**
+ * Try to parse a deep link and reject obviously unsafe values.
+ * A safe link is expected to:
+ *  - be a string shorter than `maxLength`
+ *  - be a valid URL or query string
+ *  - contain query parameter values made of safe characters
+ *
+ * On success the function returns parsed query parameters,
+ * otherwise it returns `null`.
+ */
+export default function deepLinkGuard(link: string, maxLength = 2048): DeepLinkParams | null {
+  if (typeof link !== 'string') {
+    return null;
+  }
+
+  // Reject extremely long links – they may be an attack vector
+  if (link.length > maxLength) {
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    // Support both full URLs and query strings ("?foo=bar")
+    url = link.startsWith('http://') || link.startsWith('https://')
+      ? new URL(link)
+      : new URL(link, 'http://local');
+  } catch (e) {
+    // Malformed URI
+    return null;
+  }
+
+  const params: DeepLinkParams = {};
+
+  // Only allow alphanumeric, dash, underscore, dot and slash in param values
+  const unsafe = /[^\w\-./]/;
+
+  // Iterate through parameters and validate
+  url.searchParams.forEach((value, key) => {
+    if (unsafe.test(value)) {
+      params.__unsafe = '1';
+      return;
+    }
+
+    if (value.length > 256) {
+      params.__unsafe = '1';
+      return;
+    }
+
+    params[key] = value;
+  });
+
+  if ('__unsafe' in params) {
+    return null;
+  }
+
+  return params;
+}

--- a/tests/security/deepLink.test.ts
+++ b/tests/security/deepLink.test.ts
@@ -1,0 +1,18 @@
+import deepLinkGuard from '../../src/utils/deepLinkGuard';
+
+describe('deepLinkGuard', () => {
+  it('parses valid link', () => {
+    const res = deepLinkGuard('https://example.com/?foo=bar');
+    expect(res).toEqual({ foo: 'bar' });
+  });
+
+  it('rejects malformed link', () => {
+    // missing scheme and bad characters
+    expect(deepLinkGuard('http://exa mple.com?foo=bar')).toBeNull();
+  });
+
+  it('rejects oversized link', () => {
+    const big = 'https://example.com/?data=' + 'a'.repeat(5000);
+    expect(deepLinkGuard(big)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add deep link guard utility to reject malformed or unsafe URLs
- display fallback toast when deep link invalid
- test malformed and oversized deep link URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b48d5351a08328b7052dc11319b62f