### PR TITLE
feat: add cache debugging utilities

### DIFF
--- a/src/components/CacheOverlay.tsx
+++ b/src/components/CacheOverlay.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+interface DebugInfo {
+  cacheControl: string;
+  cdnStatus: string;
+  etag: string;
+  responseTime: number;
+  hitRate: number;
+}
+
+const CacheOverlay: React.FC = () => {
+  const [info, setInfo] = useState<DebugInfo | null>(null);
+
+  useEffect(() => {
+    const path = window.location.pathname;
+    fetch(`/cache-debug?path=${encodeURIComponent(path)}`)
+      .then((res) => res.json())
+      .then((data: DebugInfo) => setInfo(data))
+      .catch(() => {
+        // ignore
+      });
+  }, []);
+
+  if (!info) {
+    return null;
+  }
+
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    bottom: 0,
+    right: 0,
+    background: 'rgba(0, 0, 0, 0.7)',
+    color: '#fff',
+    padding: '8px',
+    fontSize: '12px',
+    zIndex: 9999,
+  };
+
+  return (
+    <div style={style}>
+      <div>L1/Cache-Control: {info.cacheControl || 'n/a'}</div>
+      <div>CDN: {info.cdnStatus}</div>
+      <div>ETag: {info.etag || 'n/a'}</div>
+      <div>Hit Rate: {(info.hitRate * 100).toFixed(1)}%</div>
+      <div>Response: {info.responseTime.toFixed(2)}ms</div>
+    </div>
+  );
+};
+
+export default CacheOverlay;

--- a/src/metrics/cacheCounters.ts
+++ b/src/metrics/cacheCounters.ts
@@ -1,0 +1,35 @@
+interface Counter {
+  hits: number;
+  total: number;
+}
+
+const counters: Map<string, Counter> = new Map();
+
+export function recordHit(path: string, hit: boolean): void {
+  const counter = counters.get(path) || { hits: 0, total: 0 };
+  counter.total += 1;
+  if (hit) {
+    counter.hits += 1;
+  }
+  counters.set(path, counter);
+}
+
+export function getHitRate(path: string): number {
+  const counter = counters.get(path);
+  if (!counter || counter.total === 0) {
+    return 0;
+  }
+  return counter.hits / counter.total;
+}
+
+export function getCounters(): Record<string, Counter> {
+  const result: Record<string, Counter> = {};
+  counters.forEach((value, key) => {
+    result[key] = { ...value };
+  });
+  return result;
+}
+
+export function resetCounters(): void {
+  counters.clear();
+}

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,13 +1,11 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import cacheDebugRoute from '../../server/routes/cache-debug';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   run(app: Application, server: WebpackDevServer, compiler: Compiler): void {
-    // app.get('/api/sh/build', async (req: any, resp: any) => {
-    //   const response = await build();
-    //   resp.json(response);
-    // });
+    app.use(cacheDebugRoute);
   }
 }

--- a/src/server/routes/cache-debug.ts
+++ b/src/server/routes/cache-debug.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import { recordHit, getHitRate } from '../../metrics/cacheCounters';
+
+const router = express.Router();
+
+router.get('/cache-debug', (req: any, res: any) => {
+  const start = process.hrtime();
+  const cacheControl = res.get('Cache-Control') || req.headers['cache-control'] || '';
+  const cdnStatus = req.headers['x-cache'] || req.headers['cdn-cache-status'] || 'MISS';
+  const etag = res.get('ETag') || req.headers['if-none-match'] || '';
+
+  const path = (req.query.path as string) || req.path;
+  const isHit = typeof cdnStatus === 'string' && cdnStatus.toUpperCase().includes('HIT');
+  recordHit(path, isHit);
+  const hitRate = getHitRate(path);
+
+  const diff = process.hrtime(start);
+  const responseTime = diff[0] * 1000 + diff[1] / 1e6;
+
+  res.json({
+    cacheControl,
+    cdnStatus,
+    etag,
+    responseTime,
+    hitRate,
+  });
+});
+
+export default router;

--- a/tests/metrics/cacheCounters.test.ts
+++ b/tests/metrics/cacheCounters.test.ts
@@ -1,0 +1,19 @@
+import { recordHit, getHitRate, resetCounters } from '../../src/metrics/cacheCounters';
+
+describe('cacheCounters', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it('calculates hit rate per path', () => {
+    recordHit('/foo', true);
+    recordHit('/foo', false);
+    recordHit('/foo', true);
+
+    expect(getHitRate('/foo')).toBeCloseTo(2 / 3);
+  });
+
+  it('returns 0 for unknown paths', () => {
+    expect(getHitRate('/unknown')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add cache debug route exposing caching headers and response time
- implement client cache overlay for L1/CDN status
- track per-path hit rates with in-memory counters

## Testing
- `yarn lint && echo LINT-PASSED`
- `yarn test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b48d4b5d608328ae1d526f08993720