### PR TITLE
feat: add hashed GraphQL endpoint and codegen

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ webpack.config.ts
 .eslintrc.js
 jest.config.js
 coverage/
+scripts/

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "graphql:codegen": "node scripts/graphql-codegen.js"
   },
   "browserslist": [
     "defaults",

--- a/scripts/graphql-codegen.js
+++ b/scripts/graphql-codegen.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const operationsDir = path.resolve(__dirname, '../src/graphql/operations');
+const typesFile = path.resolve(__dirname, '../src/graphql/types.d.ts');
+const opsFile = path.resolve(__dirname, '../src/graphql/operations.json');
+
+const files = fs.readdirSync(operationsDir).filter((f) => f.endsWith('.graphql'));
+const types = [];
+const ops = {};
+
+files.forEach((file) => {
+  const name = path.basename(file, '.graphql');
+  const content = fs.readFileSync(path.join(operationsDir, file), 'utf8').trim();
+  const hash = crypto.createHash('sha256').update(content).digest('hex');
+  ops[hash] = content;
+  types.push(`/** @typedef {{}} ${name}Data */\n/** @typedef {{}} ${name}Variables */\n`);
+});
+
+fs.writeFileSync(typesFile, `${types.join('\n')}\n`);
+fs.writeFileSync(opsFile, `${JSON.stringify(ops, null, 2)}\n`);
+

--- a/src/graphql/cache.ts
+++ b/src/graphql/cache.ts
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+import { Request, Response } from 'express';
+
+interface CacheEntry {
+  etag: string;
+  expires: number;
+  payload: any;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+const DEFAULT_TTL = 60 * 1000; // 1 minute
+
+export function sendCached(key: string, req: Request, res: Response): boolean {
+  const entry = cache.get(key);
+  if (!entry || Date.now() > entry.expires) {
+    cache.delete(key);
+    return false;
+  }
+  if (req.headers['if-none-match'] === entry.etag) {
+    res.status(304).end();
+    return true;
+  }
+  res.setHeader('ETag', entry.etag);
+  res.json(entry.payload);
+  return true;
+}
+
+export function storeCached(key: string, res: Response, payload: any, ttl = DEFAULT_TTL): void {
+  const etag = crypto.createHash('sha1').update(JSON.stringify(payload)).digest('hex');
+  cache.set(key, { etag, expires: Date.now() + ttl, payload });
+  res.setHeader('ETag', etag);
+  res.json(payload);
+}

--- a/src/graphql/fetchGraphQL.ts
+++ b/src/graphql/fetchGraphQL.ts
@@ -1,0 +1,17 @@
+import operations from './operations.json';
+
+interface FetchOptions {
+  variables?: Record<string, any>;
+}
+
+export default async function fetchGraphQL(hash: string, options: FetchOptions = {}): Promise<any> {
+  if (!(hash in operations)) {
+    throw new Error('Unknown operation hash');
+  }
+  const response = await fetch('/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hash, variables: options.variables }),
+  });
+  return response.json();
+}

--- a/src/graphql/operations.json
+++ b/src/graphql/operations.json
@@ -1,0 +1,3 @@
+{
+  "d49d5eefe323696b5cc6447e1c448cf3fbfa657100d7d6296a4912b30d24e4f2": "query Viewer {\n  viewer {\n    login\n  }\n}"
+}

--- a/src/graphql/operations/Viewer.graphql
+++ b/src/graphql/operations/Viewer.graphql
@@ -1,0 +1,6 @@
+query Viewer {
+  viewer {
+    login
+  }
+}
+

--- a/src/graphql/types.d.ts
+++ b/src/graphql/types.d.ts
@@ -1,0 +1,2 @@
+/** @typedef {{}} ViewerData */
+/** @typedef {{}} ViewerVariables */

--- a/src/modules/server/Server.ts
+++ b/src/modules/server/Server.ts
@@ -1,6 +1,7 @@
 import { Compiler } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import { Application } from 'express';
+import registerGraphQL from '../../server/graphql';
 
 export default class Server {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,5 +10,6 @@ export default class Server {
     //   const response = await build();
     //   resp.json(response);
     // });
+    registerGraphQL(app);
   }
 }

--- a/src/server/graphql.ts
+++ b/src/server/graphql.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+import axios from 'axios';
+import operations from '../graphql/operations.json';
+import { sendCached, storeCached } from '../graphql/cache';
+
+export default function registerGraphQL(app: express.Application): void {
+  app.post('/graphql', async (req, res) => {
+    const { hash, variables } = req.body || {};
+    if (typeof hash !== 'string' || !(hash in operations)) {
+      res.status(400).json({ error: 'Unknown operation hash' });
+      return;
+    }
+
+    const cacheKey = `${hash}:${JSON.stringify(variables || {})}`;
+    if (sendCached(cacheKey, req, res)) {
+      return;
+    }
+
+    try {
+      const query = (operations as Record<string, string>)[hash];
+      const response = await axios.post('https://api.github.com/graphql', {
+        query,
+        variables,
+      });
+      storeCached(cacheKey, res, response.data);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add Express `/graphql` POST endpoint using SHA256 hashed operations and ETag caching
- generate GraphQL operation hashes and JSDoc typedefs via `npm run graphql:codegen`
- expose `fetchGraphQL` helper that only accepts pre-hashed queries

## Testing
- `npm run graphql:codegen`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48d4af2bc8328b509640e127c3f5d