### PR TITLE
feat: add import map and dedupe check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,8 @@ module.exports = {
     'global-require': 0,
     'class-methods-use-this': 0,
     'import/no-extraneous-dependencies': 0,
+    'import/no-internal-modules': ['error', {
+      allow: ['**/src/**', '**/tests/**']
+    }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "release": "yarn standard-version",
     "github:profile": "ts-node ./src/services/github/utils/profile.ts",
     "github:repositories": "ts-node ./src/services/github/utils/repositories.ts",
-    "test": "jest"
+    "test": "jest",
+    "dedupe-check": "yarn dedupe --check"
   },
   "browserslist": [
     "defaults",

--- a/public/import-map.json
+++ b/public/import-map.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "axios": "/node_modules/axios/dist/axios.min.js",
+    "inversify": "/node_modules/inversify/lib/inversify.js",
+    "reflect-metadata": "/node_modules/reflect-metadata/Reflect.js"
+  }
+}


### PR DESCRIPTION
## Summary
- pin shared browser dependencies via public/import-map.json
- enforce top-level imports with `import/no-internal-modules`
- add `dedupe-check` script to guard against duplicate packages

## Testing
- `npm test`
- `npm run lint`
- `npm run dedupe-check` *(fails: duplicates found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d4c47e0832891db2ccde89556e0