### PR TITLE
Implement window layout schema and recovery utility

### DIFF
--- a/src/state/windowLayout.ts
+++ b/src/state/windowLayout.ts
@@ -1,0 +1,39 @@
+export interface PanePosition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WindowLayout {
+  version: number;
+  panes: { [key: string]: PanePosition };
+  checksum: string;
+}
+
+function computeChecksum(layout: Omit<WindowLayout, 'checksum'>): string {
+  const json = JSON.stringify(layout);
+  let hash = 0;
+  for (let i = 0; i < json.length; i += 1) {
+    const chr = json.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash.toString(16);
+}
+
+export function withChecksum(layout: Omit<WindowLayout, 'checksum'>): WindowLayout {
+  return { ...layout, checksum: computeChecksum(layout) };
+}
+
+export function isValidLayout(layout: WindowLayout): boolean {
+  const { checksum, ...rest } = layout;
+  return checksum === computeChecksum(rest as Omit<WindowLayout, 'checksum'>);
+}
+
+export const defaultWindowLayout: WindowLayout = withChecksum({
+  version: 1,
+  panes: {},
+});
+
+export { computeChecksum };

--- a/src/utils/layoutRecovery.ts
+++ b/src/utils/layoutRecovery.ts
@@ -1,0 +1,50 @@
+import { WindowLayout, withChecksum, isValidLayout, defaultWindowLayout } from '../state/windowLayout';
+
+const LAYOUT_KEY = 'windowLayout';
+const BACKUP_KEYS = ['windowLayout:backup1', 'windowLayout:backup2'];
+
+function readLayout(key: string): WindowLayout | null {
+  const raw = localStorage.getItem(key);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as WindowLayout;
+  } catch (e) {
+    return null;
+  }
+}
+
+function writeLayout(key: string, layout: WindowLayout): void {
+  localStorage.setItem(key, JSON.stringify(layout));
+}
+
+export default class LayoutRecovery {
+  static save(layout: Omit<WindowLayout, 'checksum'>): void {
+    const current = localStorage.getItem(LAYOUT_KEY);
+    if (current) {
+      localStorage.setItem(BACKUP_KEYS[1], localStorage.getItem(BACKUP_KEYS[0]) || '');
+      localStorage.setItem(BACKUP_KEYS[0], current);
+    }
+    const layoutWithChecksum = withChecksum(layout);
+    writeLayout(LAYOUT_KEY, layoutWithChecksum);
+  }
+
+  static load(): WindowLayout {
+    const layout = readLayout(LAYOUT_KEY);
+    if (layout && isValidLayout(layout)) {
+      return layout;
+    }
+
+    for (const key of BACKUP_KEYS) {
+      const backup = readLayout(key);
+      if (backup && isValidLayout(backup)) {
+        writeLayout(LAYOUT_KEY, backup);
+        return backup;
+      }
+    }
+
+    writeLayout(LAYOUT_KEY, defaultWindowLayout);
+    return defaultWindowLayout;
+  }
+}

--- a/tests/utils/layoutRecovery.test.ts
+++ b/tests/utils/layoutRecovery.test.ts
@@ -1,0 +1,46 @@
+import LayoutRecovery from '../../src/utils/layoutRecovery';
+import { defaultWindowLayout } from '../../src/state/windowLayout';
+
+class LocalStorageMock {
+  private store: { [key: string]: string } = {};
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key: string): string | null {
+    return this.store[key] || null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value.toString();
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+}
+
+beforeEach(() => {
+  (global as any).localStorage = new LocalStorageMock();
+});
+
+describe('LayoutRecovery', () => {
+  it('saves backups of last two layouts', () => {
+    LayoutRecovery.save({ version: 1, panes: { first: { x: 0, y: 0, width: 10, height: 10 } } });
+    LayoutRecovery.save({ version: 1, panes: { second: { x: 1, y: 1, width: 20, height: 20 } } });
+    LayoutRecovery.save({ version: 1, panes: { third: { x: 2, y: 2, width: 30, height: 30 } } });
+    expect(localStorage.getItem('windowLayout:backup1')).not.toBeNull();
+    expect(localStorage.getItem('windowLayout:backup2')).not.toBeNull();
+  });
+
+  it('recovers from corruption or resets to default', () => {
+    LayoutRecovery.save({ version: 1, panes: { test: { x: 0, y: 0, width: 10, height: 10 } } });
+    const corrupted = JSON.parse(localStorage.getItem('windowLayout')!);
+    corrupted.checksum = 'corrupted';
+    localStorage.setItem('windowLayout', JSON.stringify(corrupted));
+
+    const layout = LayoutRecovery.load();
+    expect(layout).toEqual(defaultWindowLayout);
+  });
+});


### PR DESCRIPTION
## Summary
- define window layout state schema with checksum
- add layout recovery utility to detect corruption and maintain backups
- test layout recovery and backup behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46a7907208328af952d1457c2811b